### PR TITLE
fix: parse OpenSSL implicit-tagged SAN entries (dNSName, rfc822Name)

### DIFF
--- a/packages/pki-lite/src/core/CertificateValidator.ts
+++ b/packages/pki-lite/src/core/CertificateValidator.ts
@@ -1259,40 +1259,14 @@ export class CertificateValidator {
     }
 
     private extractSubjectAltNames(certificate: Certificate): SubjectAltName[] {
-        const subjectAltNames: SubjectAltName[] = []
-        const extensions = certificate.tbsCertificate.extensions
-        if (!extensions) return []
-
-        for (const ext of extensions) {
-            // Subject Alternative Name OID:
-            if (ext.extnID.value === OIDs.EXTENSION.SUBJECT_ALT_NAME) {
-                subjectAltNames.push(ext.extnValue.parseAs(SubjectAltName))
-            }
-        }
-
-        return subjectAltNames
+        return certificate.getSubjectAltNames()
     }
 
     /**
      * Extracts the common name (CN) from a certificate's subject.
      */
     private extractCommonName(certificate: Certificate): string | undefined {
-        const subject = certificate.tbsCertificate.subject
-
-        if (subject && Array.isArray(subject)) {
-            for (const rdn of subject) {
-                for (const atv of rdn) {
-                    if (atv && atv.type && atv.type.value === OIDs.DN.CN) {
-                        return atv.value.asString()
-                    }
-                }
-            }
-        }
-
-        // Fallback: extract from string representation
-        const subjectStr = subject.toString()
-        const cnMatch = subjectStr.match(/CN=([^,\]]+)/)
-        return cnMatch ? cnMatch[1].trim() : undefined
+        return certificate.getCommonName()
     }
 
     /**

--- a/packages/pki-lite/src/x509/Certificate.test.ts
+++ b/packages/pki-lite/src/x509/Certificate.test.ts
@@ -169,4 +169,36 @@ describe('Certificate', () => {
           -----END CERTIFICATE-----"
         `)
     })
+
+    // Regression test for issue #84: OpenSSL uses implicit tagging for SAN entries
+    test('getSubjectAltNames parses OpenSSL-generated certificate with implicit-tagged dNSName', () => {
+        const certPem = `-----BEGIN CERTIFICATE-----
+MIIDJTCCAg2gAwIBAgIUcrK/GL//nD5tolE0vt6Vy5EEj9YwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjYwMzMxMjAwNzM5WhcNMjcw
+MzMxMjAwNzM5WjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBALZKfc0D7gVZUn88yH9dNgseviWi55W6ZVy7Doha
+eTVC4e0qDtJycW8KVYNoc2MmJN3pnQpc5P7tFJ9I5/zaVQ3WqMVDI8lesDlwoUmI
+iFizxBxotmQOGo/G1ZU3wAGtzogs6MPZ5m10fPom7gRifT4rvl24GMXxoGZQlstE
+QSW4nrT/X5e2nzDn+qUeRTwg30u5X3j4ojLFf3IQeQuXgjNpwi1u661iXMDgDT2G
+mI9IYVoK9rAT00OUuMm024o+irA1XXDtY594jKS4QsSGHN7BCKLCM+8mw7G0oDqQ
+VNdVr8Q/SZoiL7b3+Tjo8JIPWoPsNHCMBysYHnfmdBuO5kcCAwEAAaNrMGkwHQYD
+VR0OBBYEFIKs2ZBlbwHlfokChUyYQrNk5GpAMB8GA1UdIwQYMBaAFIKs2ZBlbwHl
+fokChUyYQrNk5GpAMA8GA1UdEwEB/wQFMAMBAf8wFgYDVR0RBA8wDYILZXhhbXBs
+ZS5jb20wDQYJKoZIhvcNAQELBQADggEBAHDCvJwp9HkLMUUNzn0pNXP7YgxDDzjJ
+HTgVHdwcyz1v0u+1jJXmuWy0T6Oq79NAMIol37NinsMoH3/UNLbZc+NJ23PplHy9
+sSvpifUgAW2/JgBnQddas8IYusBdckqE2RJD2XdNHsNpyMX9SrC6PawEDT28xVx9
+gp89l0naLH02o+NguQYJv+taCGp96o9VEEhap/qUcSQI+C6RMcWth2EHAXmLaYxp
+PdX78veNZQefzueZK3mlv41LkAIYlEHgH9/p31EbDZmbZcpbPDDMOY9Xbpcu4iha
+YCq9EV5g9cM3mH/4raahln+1O63McYb36rlLFrJaQz+aX7A/9Wir1Jk=
+-----END CERTIFICATE-----`
+
+        const cert = Certificate.fromPem(certPem)
+
+        const sans = cert.getSubjectAltNames()
+        expect(sans).toHaveLength(1)
+        expect(sans[0]).toHaveLength(1)
+        expect(sans[0][0].toString()).toEqual('example.com')
+
+        expect(cert.getCommonName()).toEqual('example.com')
+    })
 })

--- a/packages/pki-lite/src/x509/Certificate.ts
+++ b/packages/pki-lite/src/x509/Certificate.ts
@@ -24,6 +24,7 @@ import { OIDs } from '../core/OIDs.js'
 import { CertificateList } from './CertificateList.js'
 import { CRLDistributionPoints } from './extensions/CRLDistributionPoints.js'
 import { GeneralName } from './GeneralName.js'
+import { SubjectAltName } from './extensions/SubjectAltName.js'
 import { OCSPResponse } from '../ocsp/OCSPResponse.js'
 import { AuthorityInfoAccess } from './extensions/AuthorityInfoAccess.js'
 import { OCSPRequest } from '../ocsp/OCSPRequest.js'
@@ -360,6 +361,56 @@ export class Certificate extends PkiBase<Certificate> {
 
     getExtensionsByName(name: keyof typeof OIDs.EXTENSION): Extension[] {
         return this.tbsCertificate.getExtensionsByName(name)
+    }
+
+    /**
+     * Returns all Subject Alternative Names from the certificate's extensions.
+     */
+    getSubjectAltNames(): SubjectAltName[] {
+        const extensions = this.tbsCertificate.extensions
+        if (!extensions) return []
+
+        return extensions
+            .filter(
+                (ext) => ext.extnID.value === OIDs.EXTENSION.SUBJECT_ALT_NAME,
+            )
+            .map((ext) => ext.extnValue.parseAs(SubjectAltName))
+    }
+
+    /**
+     * Returns all Subject Alternative Names as strings (e.g. DNS names, email addresses).
+     * This is a convenience method that extracts the string representation of each SAN entry.
+     * @returns An array of strings representing the Subject Alternative Names.
+     */
+    getSubjectAltNamesAsStrings(): string[] {
+        const sans = this.getSubjectAltNames()
+        const sanStrings: string[] = []
+        for (const san of sans) {
+            for (const name of san) {
+                sanStrings.push(name.toString())
+            }
+        }
+        return sanStrings
+    }
+
+    /**
+     * Returns the Common Name (CN) from the certificate's subject, or undefined if not present.
+     */
+    getCommonName(): string | undefined {
+        const subject = this.tbsCertificate.subject
+
+        if (subject && Array.isArray(subject)) {
+            for (const rdn of subject) {
+                for (const atv of rdn) {
+                    if (atv && atv.type && atv.type.value === OIDs.DN.CN) {
+                        return atv.value.asString()
+                    }
+                }
+            }
+        }
+
+        const cnMatch = subject.toString().match(/CN=([^,\]]+)/)
+        return cnMatch ? cnMatch[1].trim() : undefined
     }
 
     getSubjectPublicKeyInfo(): SubjectPublicKeyInfo {

--- a/packages/pki-lite/src/x509/GeneralName.ts
+++ b/packages/pki-lite/src/x509/GeneralName.ts
@@ -146,6 +146,10 @@ export class rfc822Name extends IA5String {
     }
 
     static fromAsn1(asn1: Asn1BaseBlock) {
+        if (asn1 instanceof asn1js.Primitive) {
+            return new rfc822Name({ value: asn1.valueBlock.valueHexView })
+        }
+
         return new rfc822Name({ value: super.fromAsn1(asn1).bytes })
     }
 }
@@ -159,6 +163,10 @@ export class dNSName extends IA5String {
     }
 
     static fromAsn1(asn1: Asn1BaseBlock) {
+        if (asn1 instanceof asn1js.Primitive) {
+            return new dNSName({ value: asn1.valueBlock.valueHexView })
+        }
+
         return new dNSName({ value: super.fromAsn1(asn1).bytes })
     }
 }

--- a/packages/pki-lite/src/x509/extensions/SubjectAltName.test.ts
+++ b/packages/pki-lite/src/x509/extensions/SubjectAltName.test.ts
@@ -131,6 +131,26 @@ describe('SubjectAltName', () => {
         )
     })
 
+    test('should parse dNSName from OpenSSL implicit-tagged Primitive (issue #84)', () => {
+        // OpenSSL uses implicit tagging for SAN entries, encoding dNSName as
+        // a Primitive with context-specific tag [2] instead of Constructed + IA5String
+        const asn1 = new asn1js.Sequence({
+            value: [
+                new asn1js.Primitive({
+                    idBlock: { tagClass: 3, tagNumber: 2 }, // [2] IMPLICIT dNSName
+                    valueHex: new TextEncoder().encode('example.com'),
+                }),
+            ],
+        })
+
+        const subjectAltName = SubjectAltName.fromAsn1(asn1)
+
+        expect(subjectAltName).toBeInstanceOf(SubjectAltName)
+        expect(subjectAltName.length).toEqual(1)
+        expect(subjectAltName[0]).toBeInstanceOf(dNSName)
+        expect(subjectAltName[0].toString()).toEqual('example.com')
+    })
+
     test('should handle empty ASN.1 sequence', () => {
         const asn1 = new asn1js.Sequence({ value: [] })
 


### PR DESCRIPTION
Fixes: https://github.com/jacobshirley/pki-lite/issues/84