### PR TITLE
fix: add PEM header methods to Certificate and CertificateRequest classes

### DIFF
--- a/packages/pki-lite/src/x509/Certificate.ts
+++ b/packages/pki-lite/src/x509/Certificate.ts
@@ -653,4 +653,8 @@ export class Certificate extends PkiBase<Certificate> {
         const validator = new CertificateValidator()
         return await validator.validate(this, options)
     }
+
+    get pemHeader(): string {
+        return 'CERTIFICATE'
+    }
 }

--- a/packages/pki-lite/src/x509/CertificateRequest.test.ts
+++ b/packages/pki-lite/src/x509/CertificateRequest.test.ts
@@ -159,9 +159,9 @@ describe('CertificateRequest', () => {
     test('CertificateRequest toPem snapshot', () => {
         const request = createSampleRequest()
         expect(request.toPem()).toMatchInlineSnapshot(`
-          "-----BEGIN CERTIFICATEREQUEST-----
+          "-----BEGIN CERTIFICATE REQUEST-----
           MIGJMHICAQAwQDEVMBMGA1UEAxMMVGVzdCBSZXF1ZXN0MRowGAYDVQQKExFUZXN0IE9yZ2FuaXphdGlvbjELMAkGA1UEBhMCVVMwFTALBgkqhkiG9w0BAQEDBgABAgMEBaAUMRIwEAYJKoZIhvcNAQkOMQMBAQAwCwYJKoZIhvcNAQELAwYAChQeKDI=
-          -----END CERTIFICATEREQUEST-----"
+          -----END CERTIFICATE REQUEST-----"
         `)
     })
 })

--- a/packages/pki-lite/src/x509/CertificateRequest.ts
+++ b/packages/pki-lite/src/x509/CertificateRequest.ts
@@ -1,4 +1,10 @@
-import { Asn1BaseBlock, asn1js, PkiBase } from '../core/PkiBase.js'
+import {
+    Asn1BaseBlock,
+    asn1js,
+    derToAsn1,
+    pemToDer,
+    PkiBase,
+} from '../core/PkiBase.js'
 import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
 import { CertificateRequestInfo } from './CertificateRequestInfo.js'
 import { BitString } from '../asn1/BitString.js'
@@ -45,6 +51,10 @@ export class CertificateRequest extends PkiBase<CertificateRequest> {
                 this.signature.toAsn1(),
             ],
         })
+    }
+
+    static fromDer(der: Uint8Array<ArrayBuffer>): CertificateRequest {
+        return CertificateRequest.fromAsn1(derToAsn1(der))
     }
 
     /**
@@ -100,5 +110,13 @@ export class CertificateRequest extends PkiBase<CertificateRequest> {
             signatureAlgorithm,
             signature,
         })
+    }
+
+    static fromPem(pem: string): CertificateRequest {
+        return CertificateRequest.fromDer(pemToDer(pem, 'CERTIFICATE REQUEST'))
+    }
+
+    get pemHeader(): string {
+        return 'CERTIFICATE REQUEST'
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/jacobshirley/pki-lite/issues/102