### PR TITLE
feat: add builder pattern for certificate requests, timestamp, ocsp, and pfx

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -822,3 +822,510 @@ console.log('  • certificate.toPem() - Export as PEM')
 console.log('  • certificate.toDer() - Export as DER')
 console.log('  • certificate.toString() - View ASN.1 structure')
 ```
+
+## Building a PKCS#12 (PFX) file with certificate and private key
+
+```typescript
+import { PFX } from 'pki-lite/pkcs12/PFX.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+
+console.log('=== PFX Builder Examples ===\n')
+
+// Generate a key pair for the examples
+console.log('Generating RSA key pair...')
+const keyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+console.log('✓ Key pair generated\n')
+
+// Create a self-signed certificate
+console.log('Creating self-signed certificate...')
+const certificate = await Certificate.builder()
+    .setSubject('CN=Example User, O=Example Org, C=US')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .selfSign()
+console.log('✓ Certificate created\n')
+
+// Example 1: Basic PFX with certificate and private key
+console.log('=== Example 1: Basic PFX with Certificate and Private Key ===')
+const basicPfx = await PFX.builder()
+    .addCertificate(certificate)
+    .addPrivateKey(keyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .build()
+
+console.log('✓ PFX created')
+console.log('  Has MAC data:', !!basicPfx.macData)
+console.log('  PFX size:', basicPfx.toDer().length, 'bytes\n')
+
+// Example 2: PFX with friendly name
+console.log('=== Example 2: PFX with Friendly Name ===')
+const namedPfx = await PFX.builder()
+    .addCertificate(certificate)
+    .addPrivateKey(keyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .setFriendlyName('My Digital Identity')
+    .setIterations(100000) // Higher iterations for better security
+    .build()
+
+console.log('✓ PFX with friendly name created')
+console.log('  Iterations:', namedPfx.macData?.iterations)
+console.log('  PFX size:', namedPfx.toDer().length, 'bytes\n')
+
+// Example 3: PFX with certificate chain
+console.log('=== Example 3: PFX with Certificate Chain ===')
+
+// Generate a CA key pair
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+
+// Create a CA certificate
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2) // CA with pathLen=2
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+
+// Create an end-entity certificate signed by CA
+const endEntityKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const endEntityCert = await Certificate.builder()
+    .setSubject('CN=End Entity, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey) // Signed by CA
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        clientAuth: true,
+        emailProtection: true,
+    })
+    .build()
+
+// Build PFX with certificate chain
+const chainPfx = await PFX.builder()
+    .addCertificate(endEntityCert) // End entity cert first
+    .addCertificate(caCert) // CA cert for chain
+    .addPrivateKey(endEntityKeyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .setFriendlyName('My Identity with Chain')
+    .setIterations(100000)
+    .build()
+
+console.log('✓ PFX with certificate chain created')
+console.log('  Certificates in chain: 2')
+console.log('  PFX size:', chainPfx.toDer().length, 'bytes\n')
+
+// Example 4: Export and verify PFX
+console.log('=== Example 4: Export and Verify PFX ===')
+
+// Export to PEM format
+const pfxPem = basicPfx.toPem()
+console.log('✓ PFX exported to PEM format')
+console.log('  PEM preview:', pfxPem.substring(0, 50) + '...\n')
+
+// Verify by parsing and extracting contents
+const password = 'mySecurePassword123'
+const parsedPfx = PFX.fromPem(pfxPem)
+
+const extractedCerts = await parsedPfx.getX509Certificates(password)
+const extractedKeys = await parsedPfx.getPrivateKeys(password)
+
+console.log('✓ PFX verified successfully')
+console.log('  Extracted certificates:', extractedCerts.length)
+console.log('  Extracted private keys:', extractedKeys.length)
+console.log(
+    '  Certificate subject:',
+    extractedCerts[0].tbsCertificate.subject.toString(),
+)
+
+// Example 5: Using PFX.create() shorthand
+console.log('\n=== Example 5: Using PFX.create() Shorthand ===')
+const shorthandPfx = await PFX.create({
+    certificates: [certificate],
+    privateKeys: [keyPair.privateKey],
+    password: 'mySecurePassword123',
+    friendlyName: 'Quick Identity',
+})
+
+console.log('✓ PFX created using shorthand method')
+console.log('  PFX size:', shorthandPfx.toDer().length, 'bytes')
+```
+
+## Building encrypted data using the EncryptedData builder
+
+```typescript
+import { EncryptedData } from 'pki-lite/pkcs7/EncryptedData.js'
+import { OIDs } from 'pki-lite/core/OIDs.js'
+import { getCryptoProvider } from 'pki-lite/core/crypto/provider.js'
+
+console.log('=== EncryptedData Builder Examples ===\n')
+
+const secretMessage = new TextEncoder().encode(
+    'This is a secret message that needs to be encrypted!',
+)
+const password = 'mySecurePassword123'
+
+// Example 1: Basic encryption with default settings (PBES2)
+console.log('=== Example 1: Basic Encryption with Default Settings ===')
+const basicEncrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .build()
+
+console.log('✓ Data encrypted with default PBES2 algorithm')
+console.log('  Version:', basicEncrypted.version)
+console.log(
+    '  Content type:',
+    basicEncrypted.encryptedContentInfo.contentType.value,
+)
+console.log(
+    '  Encrypted size:',
+    basicEncrypted.encryptedContentInfo.encryptedContent?.bytes.length,
+    'bytes',
+)
+console.log(
+    '  Algorithm:',
+    basicEncrypted.encryptedContentInfo.contentEncryptionAlgorithm.friendlyName,
+)
+
+// Decrypt to verify
+const provider = getCryptoProvider()
+const algorithm1 = provider.toSymmetricEncryptionAlgorithmParams(
+    basicEncrypted.encryptedContentInfo.contentEncryptionAlgorithm,
+)
+const decrypted1 = await provider.decryptSymmetric(
+    basicEncrypted.encryptedContentInfo.encryptedContent!.bytes,
+    password as any, // Type definitions need updating to accept string
+    algorithm1,
+)
+console.log('✓ Decrypted successfully:', new TextDecoder().decode(decrypted1))
+console.log()
+
+// Example 2: Encryption with custom PBKDF2 iterations
+console.log('=== Example 2: Custom Iterations for PBKDF2 ===')
+const customIterations = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 100000, // Higher security
+                    hash: 'SHA-256',
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_256_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted with 100,000 PBKDF2 iterations')
+console.log(
+    '  Algorithm:',
+    customIterations.encryptedContentInfo.contentEncryptionAlgorithm
+        .friendlyName,
+)
+console.log()
+
+// Example 3: Encryption with SHA-512 hash
+console.log('=== Example 3: Using SHA-512 for Key Derivation ===')
+const sha512Encrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 50000,
+                    hash: 'SHA-512', // More secure hash
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_256_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted using SHA-512 for key derivation')
+console.log(
+    '  Algorithm:',
+    sha512Encrypted.encryptedContentInfo.contentEncryptionAlgorithm
+        .friendlyName,
+)
+console.log()
+
+// Example 4: Encryption with AES-128 (smaller key size)
+console.log('=== Example 4: Using AES-128-CBC ===')
+const aes128Encrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 10000,
+                    hash: 'SHA-256',
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_128_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted with AES-128-CBC')
+console.log()
+
+// Example 5: Using EncryptedData.create() shorthand
+console.log('=== Example 5: Using EncryptedData.create() Shorthand ===')
+const shorthand = await EncryptedData.create({
+    contentType: 'DATA',
+    data: secretMessage,
+    password,
+    iterations: 50000,
+})
+
+console.log('✓ Data encrypted using shorthand method')
+console.log('  Encrypted size:', shorthand.toDer().length, 'bytes')
+console.log()
+
+// Example 6: Export to DER and convert to CMS
+console.log('=== Example 6: Export and Convert to CMS ===')
+const der = basicEncrypted.toDer()
+console.log('✓ Encrypted data exported to DER')
+console.log('  DER size:', der.length, 'bytes')
+
+// Convert to CMS ContentInfo
+const cms = basicEncrypted.asCms()
+console.log('✓ Converted to CMS ContentInfo')
+console.log('  Content type:', cms.contentType.value)
+console.log('  CMS size:', cms.toDer().length, 'bytes')
+```
+
+## Building a Certificate Revocation List (CRL) using the CertificateList builder
+
+```typescript
+import { CertificateList } from 'pki-lite/x509/CertificateList.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { Extension } from 'pki-lite/x509/Extension.js'
+import { OIDs } from 'pki-lite/core/OIDs.js'
+
+console.log('=== CRL Builder Examples ===\n')
+
+// First, create a CA certificate and key pair
+console.log('Setting up CA...')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2)
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+console.log('✓ CA certificate created\n')
+
+// Create some end-entity certificates to revoke
+console.log('Creating certificates to revoke...')
+const cert1KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert1 = await Certificate.builder()
+    .setSubject('CN=User 1, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert1KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(1001)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .build()
+
+const cert2KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert2 = await Certificate.builder()
+    .setSubject('CN=User 2, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert2KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(1002)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .build()
+
+console.log('✓ Test certificates created\n')
+
+// Example 1: Basic CRL with revoked certificates
+console.log('=== Example 1: Basic CRL with Revoked Certificates ===')
+const basicCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setThisUpdate(new Date())
+    .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)) // 30 days
+    .addRevokedCertificate({
+        serialNumber: 1001,
+        revocationDate: new Date(),
+    })
+    .addRevokedCertificate({
+        serialNumber: 1002,
+        revocationDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
+    })
+    .build()
+
+console.log('✓ Basic CRL created')
+console.log('  Issuer:', basicCrl.tbsCertList.issuer.toString())
+console.log('  This Update:', basicCrl.tbsCertList.thisUpdate)
+console.log('  Next Update:', basicCrl.tbsCertList.nextUpdate)
+console.log(
+    '  Revoked Certificates:',
+    basicCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log('  CRL size:', basicCrl.toDer().length, 'bytes\n')
+
+// Example 2: Revoking certificates by reference
+console.log('=== Example 2: Revoking Certificates by Reference ===')
+const referenceCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .revokeCertificate(cert1) // Revokes using current time
+    .revokeCertificate(cert2, new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)) // 14 days ago
+    .build()
+
+console.log('✓ CRL created by revoking certificate references')
+console.log(
+    '  Revoked Certificates:',
+    referenceCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log()
+
+// Example 3: CRL with CRL Number extension
+console.log('=== Example 3: CRL with CRL Number Extension ===')
+const crlNumberExtension = new Extension({
+    extnID: OIDs.EXTENSION.CRL_NUMBER,
+    critical: false,
+    extnValue: new Uint8Array([0x02, 0x01, 0x01]), // Integer 1 (ASN.1 DER encoded)
+})
+
+const numberedCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .addExtension(crlNumberExtension)
+    .revokeCertificate(cert1)
+    .build()
+
+console.log('✓ CRL with CRL Number extension created')
+console.log('  Extensions:', numberedCrl.tbsCertList.extensions?.length || 0)
+console.log(
+    '  CRL version:',
+    numberedCrl.tbsCertList.version === 1 ? 'v2' : 'v1',
+)
+console.log()
+
+// Example 4: Empty CRL (no revoked certificates)
+console.log('=== Example 4: Empty CRL ===')
+const emptyCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setThisUpdate(new Date())
+    .setNextUpdate(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)) // 7 days
+    .build()
+
+console.log('✓ Empty CRL created (no revoked certificates)')
+console.log(
+    '  Revoked Certificates:',
+    emptyCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log('  CRL version:', emptyCrl.tbsCertList.version === 1 ? 'v2' : 'v1')
+console.log()
+
+// Example 5: Export and parse CRL
+console.log('=== Example 5: Export and Parse CRL ===')
+
+// Export to PEM
+const crlPem = basicCrl.toPem()
+console.log('✓ CRL exported to PEM format')
+console.log('  PEM preview:', crlPem.substring(0, 50) + '...')
+
+// Parse back from PEM
+const parsedCrl = CertificateList.fromPem(crlPem)
+console.log('✓ CRL parsed from PEM')
+console.log(
+    '  Issuer matches:',
+    parsedCrl.tbsCertList.issuer.toString() ===
+        basicCrl.tbsCertList.issuer.toString(),
+)
+console.log(
+    '  Revoked count matches:',
+    parsedCrl.tbsCertList.revokedCertificates?.length ===
+        basicCrl.tbsCertList.revokedCertificates?.length,
+)
+console.log()
+
+// Example 6: Checking if a certificate is revoked
+console.log('=== Example 6: Checking Revocation Status ===')
+const serialToCheck = cert1.tbsCertificate.serialNumber.toString()
+const isRevoked = basicCrl.tbsCertList.revokedCertificates?.some(
+    (revoked) => revoked.userCertificate.toString() === serialToCheck,
+)
+
+console.log(
+    `Certificate with serial ${serialToCheck}:`,
+    isRevoked ? 'REVOKED' : 'Valid',
+)
+
+if (isRevoked) {
+    const revokedEntry = basicCrl.tbsCertList.revokedCertificates?.find(
+        (revoked) => revoked.userCertificate.toString() === serialToCheck,
+    )
+    console.log('  Revocation Date:', revokedEntry?.revocationDate)
+}
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -250,3 +250,575 @@ console.log(envelopedData.toCms())
 const decrypted = await envelopedData.decrypt(privateKey)
 console.log('Decrypted:', new TextDecoder().decode(decrypted))
 ```
+
+## Generating RSA and EC key pairs
+
+```typescript
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+
+// Generate an RSA key pair with 2048-bit key size
+console.log('Generating RSA-2048 key pair...')
+const rsaKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+
+console.log('RSA Private Key (PEM):')
+console.log(rsaKeyPair.privateKey.toPem())
+console.log('\nRSA Public Key (PEM):')
+console.log(rsaKeyPair.publicKey.toPem())
+
+// Generate an ECDSA key pair using P-256 curve
+console.log('\n\nGenerating ECDSA P-256 key pair...')
+const ecKeyPair = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+
+console.log('EC Private Key (PEM):')
+console.log(ecKeyPair.privateKey.toPem())
+console.log('\nEC Public Key (PEM):')
+console.log(ecKeyPair.publicKey.toPem())
+
+// Generate an ECDSA key pair using P-384 curve
+console.log('\n\nGenerating ECDSA P-384 key pair...')
+const ecP384KeyPair = await KeyGen.generateEcPair({ namedCurve: 'P-384' })
+
+console.log('EC P-384 Private Key (PEM):')
+console.log(ecP384KeyPair.privateKey.toPem())
+
+// You can also extract the raw key objects
+const privateKey = rsaKeyPair.privateKey.getPrivateKey()
+console.log('\n\nRSA Private Key type:', privateKey.constructor.name)
+
+const ecPrivateKey = ecKeyPair.privateKey.getPrivateKey()
+console.log('EC Private Key type:', ecPrivateKey.constructor.name)
+```
+
+## Creating a Certificate Signing Request (CSR) / PKCS#10
+
+```typescript
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { CertificateRequest } from 'pki-lite/x509/CertificateRequest.js'
+
+// Generate a key pair
+console.log('Generating RSA key pair...')
+const keyPair = await KeyGen.generateRsaPair()
+console.log('✓ Key pair generated\n')
+
+// Build and sign the CSR
+const csr = await CertificateRequest.builder()
+    .setSubject('CN=example.com, O=Example Organization, C=US')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+    })
+    .addSubjectAltName('example.com', 'www.example.com')
+    .build()
+
+// Output the CSR in PEM format
+console.log('Certificate Signing Request (PEM):')
+console.log(csr.toPem())
+
+// You can also verify the CSR by parsing it back
+const parsedCsr = CertificateRequest.fromPem(csr.toPem())
+console.log('\n✓ CSR successfully created and parsed')
+console.log('Subject:', parsedCsr.requestInfo.subject.toString())
+console.log(
+    'Signature Algorithm:',
+    parsedCsr.signatureAlgorithm.algorithm.toString(),
+)
+console.log(
+    'Number of attributes:',
+    parsedCsr.requestInfo.attributes?.length ?? 0,
+)
+```
+
+## Creating a CA certificate and issuing end-entity certificates
+
+```typescript
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+
+console.log('=== Step 1: Generate CA Key Pair ===')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 4096 })
+console.log('✓ CA key pair generated')
+
+console.log('\n=== Step 2: Create CA Certificate (Self-Signed) ===')
+
+// Build and sign the CA certificate
+const caCertificate = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Organization, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 0) // CA with path length 0
+    .addKeyUsage({
+        keyCertSign: true, // Can sign certificates
+        cRLSign: true, // Can sign CRLs
+    })
+    .selfSign()
+
+console.log('✓ CA certificate created')
+console.log('  Subject:', caCertificate.tbsCertificate.subject.toString())
+console.log('  Serial:', caCertificate.tbsCertificate.serialNumber.toString())
+console.log(
+    '  Valid from:',
+    caCertificate.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    caCertificate.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+console.log('\n=== Step 3: Generate End-Entity Key Pair ===')
+const endEntityKeyPair = await KeyGen.generateRsaPair()
+console.log('✓ End-entity key pair generated')
+
+console.log('\n=== Step 4: Issue End-Entity Certificate ===')
+
+// Build and sign the end-entity certificate with the CA
+const endEntityCertificate = await Certificate.builder()
+    .setSubject('CN=example.com, O=Example Organization, C=US')
+    .setIssuer(caCertificate) // The CA certificate
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setIssuerPrivateKey(caKeyPair.privateKey) // Sign with CA's private key
+    .setValidityDays(365) // 1 year
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+        clientAuth: true,
+    })
+    .addSubjectAltName('example.com', 'www.example.com', '*.example.com')
+    .sign()
+
+console.log('✓ End-entity certificate issued')
+console.log(
+    '  Subject:',
+    endEntityCertificate.tbsCertificate.subject.toString(),
+)
+console.log('  Issuer:', endEntityCertificate.tbsCertificate.issuer.toString())
+console.log(
+    '  Serial:',
+    endEntityCertificate.tbsCertificate.serialNumber.toString(),
+)
+console.log(
+    '  Valid from:',
+    endEntityCertificate.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    endEntityCertificate.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+console.log('\n=== Step 5: Verify Certificate Chain ===')
+// Verify the signature on the end-entity certificate using the CA's public key
+const isValid = await endEntityCertificate.isIssuedBy(caCertificate)
+console.log('✓ Certificate chain verification:', isValid ? 'VALID' : 'INVALID')
+
+console.log('\n=== Certificates in PEM Format ===')
+console.log('\n--- CA Certificate ---')
+console.log(caCertificate.toPem())
+
+console.log('\n--- End-Entity Certificate ---')
+console.log(endEntityCertificate.toPem())
+
+console.log('\n--- End-Entity Private Key ---')
+console.log(endEntityKeyPair.privateKey.toPem())
+```
+
+## Certificate chain building and validation
+
+```typescript
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { CertificateValidator } from 'pki-lite/core/CertificateValidator.js'
+
+// For this example, you would typically load real certificates
+// Here we show how to use the validator with placeholder certificates
+
+console.log('=== Certificate Chain Validation Example ===\n')
+
+// Example 1: Load certificates from PEM strings
+const rootCertPem = `-----BEGIN CERTIFICATE-----
+{your root CA certificate here}
+-----END CERTIFICATE-----`
+
+const intermediateCertPem = `-----BEGIN CERTIFICATE-----
+{your intermediate CA certificate here}
+-----END CERTIFICATE-----`
+
+const endEntityCertPem = `-----BEGIN CERTIFICATE-----
+{your end-entity certificate here}
+-----END CERTIFICATE-----`
+
+// Parse the certificates
+const rootCert = Certificate.fromPem(rootCertPem)
+const intermediateCert = Certificate.fromPem(intermediateCertPem)
+const endEntityCert = Certificate.fromPem(endEntityCertPem)
+
+console.log('Loaded certificates:')
+console.log('  Root CA:', rootCert.tbsCertificate.subject.toString())
+console.log(
+    '  Intermediate CA:',
+    intermediateCert.tbsCertificate.subject.toString(),
+)
+console.log('  End Entity:', endEntityCert.tbsCertificate.subject.toString())
+
+console.log('\n=== Validation 1: Basic Certificate Validation ===')
+const validator = new CertificateValidator()
+
+// Validate just the end-entity certificate (without chain validation)
+const basicValidation = await validator.validate(endEntityCert, {
+    checkSignature: false, // Don't check signature without issuer
+})
+
+console.log('Validation Status:', basicValidation.status)
+console.log('Is Valid:', basicValidation.isValid)
+console.log('Messages:', basicValidation.messages.join(', '))
+console.log('Validated At:', basicValidation.validatedAt.toISOString())
+
+console.log('\n=== Validation 2: Certificate Chain Validation ===')
+
+// Validate the full certificate chain
+const chainValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    checkSignature: true,
+    enforceCAConstraints: true,
+    trustAnchors: [
+        {
+            certificate: rootCert,
+        },
+    ],
+    otherCertificates: [intermediateCert], // Intermediate certificates for chain building
+})
+
+console.log('Chain Validation Status:', chainValidation.status)
+console.log('Is Valid:', chainValidation.isValid)
+console.log('Messages:', chainValidation.messages.join(', '))
+
+if (chainValidation.chain) {
+    console.log('\nCertificate Chain:')
+    console.log('  Is Complete:', chainValidation.chain.isComplete)
+    console.log('  Chain Length:', chainValidation.chain.certificates.length)
+    chainValidation.chain.certificates.forEach((cert, index) => {
+        console.log(`  [${index}] ${cert.tbsCertificate.subject.toString()}`)
+    })
+}
+
+console.log('\nDiagnostics:')
+console.log(
+    '  Steps Performed:',
+    chainValidation.diagnostics.stepsPerformed.length,
+)
+chainValidation.diagnostics.stepsPerformed.forEach((step) => {
+    console.log(`    - ${step}`)
+})
+
+if (chainValidation.diagnostics.warnings.length > 0) {
+    console.log('  Warnings:', chainValidation.diagnostics.warnings.length)
+    chainValidation.diagnostics.warnings.forEach((warning) => {
+        console.log(`    ! ${warning}`)
+    })
+}
+
+console.log('\n=== Validation 3: With Custom Validation Time ===')
+
+// Validate with a specific date (useful for checking historical validity)
+const historicalDate = new Date('2023-06-01T00:00:00Z')
+const historicalValidation = await validator.validate(endEntityCert, {
+    validationTime: historicalDate,
+    timeTolerance: 300000, // 5 minutes tolerance in milliseconds
+})
+
+console.log('Historical Validation Status:', historicalValidation.status)
+console.log('Is Valid:', historicalValidation.isValid)
+console.log('Validation Time:', historicalDate.toISOString())
+
+console.log('\n=== Validation 4: With Revocation Checking (CRL) ===')
+
+// If you have CRLs available
+const crl = await endEntityCert.requestCrl()
+if (crl) {
+    const crlValidation = await validator.validate(
+        endEntityCert,
+        {
+            checkCRL: true,
+        },
+        {
+            crls: [crl],
+            issuerCertificate: intermediateCert,
+        },
+    )
+
+    console.log('CRL Validation Status:', crlValidation.status)
+    console.log('Is Valid:', crlValidation.isValid)
+    console.log('Revocation Status:')
+    console.log('  Is Revoked:', crlValidation.revocationStatus.isRevoked)
+    console.log('  Source:', crlValidation.revocationStatus.source)
+    if (crlValidation.revocationStatus.reason !== undefined) {
+        console.log('  Reason:', crlValidation.revocationStatus.reason)
+    }
+} else {
+    console.log('No CRL available for this certificate')
+}
+
+console.log('\n=== Validation 5: With Name Constraints ===')
+
+// Validate with name constraints (if the CA has name constraints)
+const nameConstraintsValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    validateNameConstraints: true,
+    trustAnchors: [
+        {
+            certificate: rootCert,
+            // nameConstraints: customNameConstraints, // Add custom constraints if needed
+        },
+    ],
+    otherCertificates: [intermediateCert],
+})
+
+console.log(
+    'Name Constraints Validation Status:',
+    nameConstraintsValidation.status,
+)
+console.log('Is Valid:', nameConstraintsValidation.isValid)
+
+console.log('\n=== Validation 6: Policy Validation ===')
+
+// Validate with required policies
+const policyValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    validatePolicies: true,
+    requiredPolicies: ['1.3.6.1.4.1.99999.1.2.3'], // Example policy OID
+    trustAnchors: [
+        {
+            certificate: rootCert,
+        },
+    ],
+    otherCertificates: [intermediateCert],
+})
+
+console.log('Policy Validation Status:', policyValidation.status)
+console.log('Is Valid:', policyValidation.isValid)
+if (policyValidation.policyResult) {
+    console.log('Policy Result:')
+    console.log('  Is Valid:', policyValidation.policyResult.isValid)
+    console.log(
+        '  Valid Policies:',
+        policyValidation.policyResult.validPolicies,
+    )
+    console.log('  Violations:', policyValidation.policyResult.violations)
+}
+
+console.log('\n=== Certificate Information ===')
+
+// Extract useful information from a certificate
+console.log('\nEnd Entity Certificate Details:')
+console.log('  Version:', endEntityCert.tbsCertificate.version + 1) // Version is 0-indexed
+console.log(
+    '  Serial Number:',
+    endEntityCert.tbsCertificate.serialNumber.toString(),
+)
+console.log('  Subject:', endEntityCert.tbsCertificate.subject.toString())
+console.log('  Issuer:', endEntityCert.tbsCertificate.issuer.toString())
+console.log(
+    '  Not Before:',
+    endEntityCert.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Not After:',
+    endEntityCert.tbsCertificate.validity.notAfter.toISOString(),
+)
+console.log(
+    '  Signature Algorithm:',
+    endEntityCert.signatureAlgorithm.algorithm.toString(),
+)
+
+if (endEntityCert.tbsCertificate.extensions) {
+    console.log('  Extensions:', endEntityCert.tbsCertificate.extensions.length)
+    endEntityCert.tbsCertificate.extensions.forEach((ext) => {
+        console.log(`    - ${ext.extnID.value} (Critical: ${ext.critical})`)
+    })
+}
+```
+
+## Using the Certificate Builder for flexible certificate creation
+
+```typescript
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { GeneralName } from 'pki-lite/x509/GeneralName.js'
+
+console.log('=== Certificate Builder Examples ===\n')
+
+// Generate keys for the examples
+console.log('Generating key pairs...')
+const keyPair1 = await KeyGen.generateRsaPair({ keySize: 2048 })
+const keyPair2 = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+console.log('✓ Key pairs generated\n')
+
+// Example 1: Basic self-signed certificate with minimal configuration
+console.log('=== Example 1: Basic Self-Signed Certificate ===')
+const basicCert = await Certificate.builder()
+    .setSubject('CN=Basic Certificate')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Basic certificate created')
+console.log('  Subject:', basicCert.tbsCertificate.subject.toString())
+console.log('  Serial:', basicCert.tbsCertificate.serialNumber.toString())
+
+// Example 2: Certificate with specific validity period
+console.log('\n=== Example 2: Certificate with Specific Validity Period ===')
+const startDate = new Date('2024-01-01T00:00:00Z')
+const endDate = new Date('2025-01-01T00:00:00Z')
+
+const timedCert = await Certificate.builder()
+    .setSubject('CN=Timed Certificate, O=Example Org')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityPeriod(startDate, endDate)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Timed certificate created')
+console.log(
+    '  Valid from:',
+    timedCert.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    timedCert.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+// Example 3: Server certificate with extensions using builder helpers
+console.log('\n=== Example 3: Server Certificate with Extensions ===')
+const serverCert = await Certificate.builder()
+    .setSubject('CN=api.example.com, O=Example Organization, C=US')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+        clientAuth: true,
+    })
+    .addSubjectAltName(
+        'api.example.com',
+        '*.api.example.com',
+        new GeneralName.rfc822Name({ value: 'admin@example.com' }),
+    )
+    .addBasicConstraints(false) // Not a CA
+    .selfSign()
+
+console.log('✓ Server certificate created')
+console.log('  Extensions:', serverCert.tbsCertificate.extensions?.length ?? 0)
+
+// Example 4: EC certificate with specific algorithm
+console.log('\n=== Example 4: EC Certificate with Custom Algorithm ===')
+const ecCert = await Certificate.builder()
+    .setSubject('CN=EC Certificate')
+    .setPublicKey(keyPair2.publicKey)
+    .setPrivateKey(keyPair2.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .setAlgorithm({
+        type: 'ECDSA',
+        params: { namedCurve: 'P-256', hash: 'SHA-256' },
+    })
+    .selfSign()
+
+console.log('✓ EC certificate created')
+console.log('  Algorithm:', ecCert.signatureAlgorithm.algorithm.toString())
+
+// Example 5: CA certificate with path length constraint
+console.log('\n=== Example 5: CA Certificate with Path Length Constraint ===')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 4096 })
+
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example Root CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 1) // CA with path length 1
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .setVersion(2) // X.509 v3
+    .selfSign()
+
+console.log('✓ CA certificate created')
+console.log('  Subject:', caCert.tbsCertificate.subject.toString())
+console.log('  Is CA: true')
+console.log('  Path Length Constraint: 1')
+
+// Example 6: Issuing a certificate from the CA
+console.log('\n=== Example 6: Certificate Issued by CA ===')
+const userKeyPair = await KeyGen.generateRsaPair()
+
+const issuedCert = await Certificate.builder()
+    .setSubject('CN=John Doe, O=Example Org, C=US')
+    .setIssuer(caCert) // Set the CA as issuer
+    .setPublicKey(userKeyPair.publicKey)
+    .setIssuerPrivateKey(caKeyPair.privateKey) // Use CA's private key to sign
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .sign()
+
+console.log('✓ User certificate issued by CA')
+console.log('  Subject:', issuedCert.tbsCertificate.subject.toString())
+console.log('  Issuer:', issuedCert.tbsCertificate.issuer.toString())
+
+// Verify the issued certificate
+const isValid = await issuedCert.isIssuedBy(caCert)
+console.log('  Signature valid:', isValid)
+
+// Example 7: Custom serial number
+console.log('\n=== Example 7: Certificate with Custom Serial Number ===')
+const customSerial = new Uint8Array([
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+])
+
+const customSerialCert = await Certificate.builder()
+    .setSubject('CN=Custom Serial')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(customSerial)
+    .selfSign()
+
+console.log('✓ Certificate with custom serial created')
+console.log(
+    '  Serial:',
+    customSerialCert.tbsCertificate.serialNumber.toString(),
+)
+
+console.log('\n=== All Examples Completed ===')
+console.log('\nCertificate Builder Features:')
+console.log('  • Fluent API for creating certificates')
+console.log('  • Helper methods for common extensions:')
+console.log('    - addKeyUsage() - Key usage flags')
+console.log('    - addExtendedKeyUsage() - Extended key usage purposes')
+console.log('    - addBasicConstraints() - CA status and path length')
+console.log('    - addSubjectAltName() - Alternative names')
+console.log('  • Support for both self-signed and CA-signed certificates')
+console.log('\nExport certificates using:')
+console.log('  • certificate.toPem() - Export as PEM')
+console.log('  • certificate.toDer() - Export as DER')
+console.log('  • certificate.toString() - View ASN.1 structure')
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -227,28 +227,47 @@ const signedData = await SignedData.builder()
 console.log(signedData.toCms())
 ```
 
-## Create a CMS EnvelopedData structure with a signer
+## Create a CMS EnvelopedData structure with a recipient
 
 ```typescript
-import { PrivateKeyInfo } from 'pki-lite/keys/PrivateKeyInfo'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
 import { EnvelopedData } from 'pki-lite/pkcs7/EnvelopedData'
 import { Certificate } from 'pki-lite/x509/Certificate'
 
-const certPem = `-----BEGIN CERTIFICATE-----{your certificate here}-----END CERTIFICATE-----`
-const privateKeyPem = `-----BEGIN PRIVATE KEY-----{your private key here}-----END PRIVATE KEY-----`
+console.log('=== Enveloped Data Example ===\n')
 
-const privateKey = PrivateKeyInfo.fromPem(privateKeyPem)
-const certificate = Certificate.fromPem(certPem)
+// Generate a key pair and create a certificate for the recipient
+console.log('Generating RSA key pair for recipient...')
+const keyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
 
+console.log('Creating recipient certificate...')
+const certificate = await Certificate.builder()
+    .setSubject('CN=Recipient, O=Example Org')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Certificate created\n')
+
+// Create enveloped data (encrypted message)
+console.log('Creating enveloped data...')
+const plaintext = 'Hello, World! This is a secret message.'
 const envelopedData = await EnvelopedData.builder()
-    .setData(new TextEncoder().encode('Hello, World!'))
+    .setData(new TextEncoder().encode(plaintext))
     .addRecipient({ certificate })
     .build()
 
-console.log(envelopedData.toCms())
+console.log('✓ Enveloped data created')
+console.log('\nEnveloped Data (CMS):')
+console.log(envelopedData.toCms().toString())
 
-const decrypted = await envelopedData.decrypt(privateKey)
-console.log('Decrypted:', new TextDecoder().decode(decrypted))
+// Decrypt the enveloped data
+console.log('\nDecrypting...')
+const decrypted = await envelopedData.decrypt(keyPair.privateKey)
+console.log('✓ Decrypted successfully')
+console.log('Decrypted text:', new TextDecoder().decode(decrypted))
 ```
 
 ## Generating RSA and EC key pairs
@@ -435,31 +454,58 @@ console.log(endEntityKeyPair.privateKey.toPem())
 ## Certificate chain building and validation
 
 ```typescript
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
 import { Certificate } from 'pki-lite/x509/Certificate.js'
 import { CertificateValidator } from 'pki-lite/core/CertificateValidator.js'
 
-// For this example, you would typically load real certificates
-// Here we show how to use the validator with placeholder certificates
-
 console.log('=== Certificate Chain Validation Example ===\n')
 
-// Example 1: Load certificates from PEM strings
-const rootCertPem = `-----BEGIN CERTIFICATE-----
-{your root CA certificate here}
------END CERTIFICATE-----`
+// Generate keys and create a certificate chain for demonstration
+console.log('Setting up certificate chain...')
 
-const intermediateCertPem = `-----BEGIN CERTIFICATE-----
-{your intermediate CA certificate here}
------END CERTIFICATE-----`
+// Generate keys for each level
+const rootKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const intermediateKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const endEntityKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
 
-const endEntityCertPem = `-----BEGIN CERTIFICATE-----
-{your end-entity certificate here}
------END CERTIFICATE-----`
+// Create root CA certificate
+const rootCert = await Certificate.builder()
+    .setSubject('CN=Root CA, O=Example Root CA, C=US')
+    .setPublicKey(rootKeyPair.publicKey)
+    .setPrivateKey(rootKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2) // CA with path length 2
+    .addKeyUsage({ keyCertSign: true, cRLSign: true })
+    .selfSign()
 
-// Parse the certificates
-const rootCert = Certificate.fromPem(rootCertPem)
-const intermediateCert = Certificate.fromPem(intermediateCertPem)
-const endEntityCert = Certificate.fromPem(endEntityCertPem)
+// Create intermediate CA certificate signed by root
+const intermediateCert = await Certificate.builder()
+    .setSubject('CN=Intermediate CA, O=Example Intermediate CA, C=US')
+    .setIssuer(rootCert.tbsCertificate.subject)
+    .setPublicKey(intermediateKeyPair.publicKey)
+    .setPrivateKey(rootKeyPair.privateKey) // Signed by root
+    .setValidityDays(1825) // 5 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 0) // CA with path length 0
+    .addKeyUsage({ keyCertSign: true, cRLSign: true })
+    .build()
+
+// Create end-entity certificate signed by intermediate
+const endEntityCert = await Certificate.builder()
+    .setSubject('CN=www.example.com, O=Example Corp, C=US')
+    .setIssuer(intermediateCert.tbsCertificate.subject)
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setPrivateKey(intermediateKeyPair.privateKey) // Signed by intermediate
+    .setValidityDays(365) // 1 year
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .addKeyUsage({ digitalSignature: true, keyEncipherment: true })
+    .addExtendedKeyUsage({ serverAuth: true })
+    .addSubjectAltName('www.example.com', 'example.com')
+    .build()
+
+console.log('✓ Certificate chain created\n')
 
 console.log('Loaded certificates:')
 console.log('  Root CA:', rootCert.tbsCertificate.subject.toString())

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1329,3 +1329,227 @@ if (isRevoked) {
     console.log('  Revocation Date:', revokedEntry?.revocationDate)
 }
 ```
+
+## Building OCSP responses using the OCSPResponse builder
+
+```typescript
+import { OCSPResponse } from 'pki-lite/ocsp/OCSPResponse.js'
+import { CertID } from 'pki-lite/ocsp/CertID.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { OCSPResponseStatus } from 'pki-lite/ocsp/OCSPResponseStatus.js'
+
+console.log('=== OCSP Response Builder Examples ===\n')
+
+// Setup: Create CA and certificates
+console.log('Setting up CA and certificates...')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const caCert = await Certificate.builder()
+    .setSubject('CN=OCSP CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2)
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+
+// Create an OCSP responder key
+const responderKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const responderCert = await Certificate.builder()
+    .setSubject('CN=OCSP Responder, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(responderKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+    })
+    .addExtendedKeyUsage({
+        ocspSigning: true,
+    })
+    .build()
+
+// Create some end-entity certificates
+const cert1KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert1 = await Certificate.builder()
+    .setSubject('CN=User 1, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert1KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(2001)
+    .build()
+
+const cert2KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert2 = await Certificate.builder()
+    .setSubject('CN=User 2, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert2KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(2002)
+    .build()
+
+console.log('✓ Setup complete\n')
+
+// Example 1: Basic OCSP response with good status (using Certificate directly)
+console.log('=== Example 1: Basic OCSP Response (Good Status) ===')
+
+const goodResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good') // Pass issuer and certificate!
+    .build()
+
+console.log('✓ OCSP response created with good status')
+console.log('  Response Status:', goodResponse.responseStatus.value)
+const basicResp1 = goodResponse.getBasicOCSPResponse()
+console.log('  Responses:', basicResp1.tbsResponseData.responses.length)
+console.log(
+    '  Certificate Status:',
+    basicResp1.tbsResponseData.responses[0].certStatus.status,
+)
+console.log('  Response size:', goodResponse.toDer().length, 'bytes\n')
+
+// Example 2: OCSP response with revoked status
+console.log('=== Example 2: OCSP Response with Revoked Status ===')
+const revocationDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // 7 days ago
+
+const revokedResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert2, 'revoked', {
+        revocationTime: revocationDate,
+        revocationReason: 0, // unspecified reason
+    })
+    .build()
+
+console.log('✓ OCSP response created with revoked status')
+const basicResp2 = revokedResponse.getBasicOCSPResponse()
+console.log(
+    '  Certificate Status:',
+    basicResp2.tbsResponseData.responses[0].certStatus.status,
+)
+console.log(
+    '  Revocation Time:',
+    basicResp2.tbsResponseData.responses[0].certStatus.revocationTime,
+)
+console.log()
+
+// Example 3: Multiple certificate responses in one OCSP response
+console.log('=== Example 3: Multiple Certificate Responses ===')
+const multiResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good') // Add multiple responses!
+    .addResponse(caCert, cert2, 'revoked', {
+        revocationTime: revocationDate,
+        revocationReason: 0,
+    })
+    .build()
+
+console.log('✓ OCSP response with multiple certificates created')
+const basicResp3 = multiResponse.getBasicOCSPResponse()
+console.log('  Total responses:', basicResp3.tbsResponseData.responses.length)
+console.log(
+    '  Response 1 status:',
+    basicResp3.tbsResponseData.responses[0].certStatus.status,
+)
+console.log(
+    '  Response 2 status:',
+    basicResp3.tbsResponseData.responses[1].certStatus.status,
+)
+console.log()
+
+// Example 4: OCSP response with custom validity period
+console.log('=== Example 4: Custom Validity Period ===')
+const now = new Date()
+const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+
+const customValidityResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .setProducedAt(now)
+    .addResponse(caCert, cert1, 'good', {
+        thisUpdate: tomorrow,
+        nextUpdate: nextWeek,
+    })
+    .build()
+
+console.log('✓ OCSP response with custom validity created')
+const basicResp4 = customValidityResponse.getBasicOCSPResponse()
+console.log('  Produced At:', basicResp4.tbsResponseData.producedAt)
+console.log(
+    '  This Update:',
+    basicResp4.tbsResponseData.responses[0].thisUpdate.time,
+)
+console.log(
+    '  Next Update:',
+    basicResp4.tbsResponseData.responses[0].nextUpdate?.time,
+)
+console.log()
+
+// Example 5: OCSP response with responder certificate included
+console.log('=== Example 5: Including Responder Certificate ===')
+const withCertResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good')
+    .addCertificate(responderCert) // Include responder cert for validation
+    .build()
+
+console.log('✓ OCSP response with responder certificate created')
+const basicResp5 = withCertResponse.getBasicOCSPResponse()
+console.log('  Included certificates:', basicResp5.certs?.length || 0)
+if (basicResp5.certs && basicResp5.certs.length > 0) {
+    console.log(
+        '  Responder cert subject:',
+        basicResp5.certs[0].tbsCertificate.subject.toString(),
+    )
+}
+console.log()
+
+// Example 6: Error response (no signature required)
+console.log('=== Example 6: Error Response ===')
+const errorResponse = await OCSPResponse.builder()
+    .setResponseStatus(OCSPResponseStatus.malformedRequest)
+    .build()
+
+console.log('✓ Error response created')
+console.log('  Response Status:', errorResponse.responseStatus.value)
+console.log('  Has response bytes:', !!errorResponse.responseBytes)
+console.log()
+
+// Example 7: Using OCSPResponse.forCertificate() shorthand
+console.log('=== Example 7: Using forCertificate() Shorthand ===')
+const shorthandResponse = await OCSPResponse.forCertificate({
+    issuerCertificate: caCert,
+    subjectCertificate: cert1,
+    privateKey: responderKeyPair.privateKey,
+    responderID: responderCert.tbsCertificate.subject,
+})
+
+console.log('✓ OCSP response created using shorthand method')
+console.log('  Response Status:', shorthandResponse.responseStatus.value)
+console.log('  Response size:', shorthandResponse.toDer().length, 'bytes')
+console.log()
+
+// Example 8: Export and parse OCSP response
+console.log('=== Example 8: Export and Parse OCSP Response ===')
+const der = goodResponse.toDer()
+console.log('✓ OCSP response exported to DER')
+console.log('  DER size:', der.length, 'bytes')
+
+const parsed = OCSPResponse.fromDer(der)
+console.log('✓ OCSP response parsed from DER')
+console.log(
+    '  Status matches:',
+    parsed.responseStatus.value === goodResponse.responseStatus.value,
+)
+```

--- a/examples/008-enveloped-data.ts
+++ b/examples/008-enveloped-data.ts
@@ -1,21 +1,40 @@
-// Create a CMS EnvelopedData structure with a signer
+// Create a CMS EnvelopedData structure with a recipient
 
-import { PrivateKeyInfo } from 'pki-lite/keys/PrivateKeyInfo'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
 import { EnvelopedData } from 'pki-lite/pkcs7/EnvelopedData'
 import { Certificate } from 'pki-lite/x509/Certificate'
 
-const certPem = `-----BEGIN CERTIFICATE-----{your certificate here}-----END CERTIFICATE-----`
-const privateKeyPem = `-----BEGIN PRIVATE KEY-----{your private key here}-----END PRIVATE KEY-----`
+console.log('=== Enveloped Data Example ===\n')
 
-const privateKey = PrivateKeyInfo.fromPem(privateKeyPem)
-const certificate = Certificate.fromPem(certPem)
+// Generate a key pair and create a certificate for the recipient
+console.log('Generating RSA key pair for recipient...')
+const keyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
 
+console.log('Creating recipient certificate...')
+const certificate = await Certificate.builder()
+    .setSubject('CN=Recipient, O=Example Org')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Certificate created\n')
+
+// Create enveloped data (encrypted message)
+console.log('Creating enveloped data...')
+const plaintext = 'Hello, World! This is a secret message.'
 const envelopedData = await EnvelopedData.builder()
-    .setData(new TextEncoder().encode('Hello, World!'))
+    .setData(new TextEncoder().encode(plaintext))
     .addRecipient({ certificate })
     .build()
 
-console.log(envelopedData.toCms())
+console.log('✓ Enveloped data created')
+console.log('\nEnveloped Data (CMS):')
+console.log(envelopedData.toCms().toString())
 
-const decrypted = await envelopedData.decrypt(privateKey)
-console.log('Decrypted:', new TextDecoder().decode(decrypted))
+// Decrypt the enveloped data
+console.log('\nDecrypting...')
+const decrypted = await envelopedData.decrypt(keyPair.privateKey)
+console.log('✓ Decrypted successfully')
+console.log('Decrypted text:', new TextDecoder().decode(decrypted))

--- a/examples/009-key-generation.ts
+++ b/examples/009-key-generation.ts
@@ -1,0 +1,35 @@
+// Generating RSA and EC key pairs
+
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+
+// Generate an RSA key pair with 2048-bit key size
+console.log('Generating RSA-2048 key pair...')
+const rsaKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+
+console.log('RSA Private Key (PEM):')
+console.log(rsaKeyPair.privateKey.toPem())
+console.log('\nRSA Public Key (PEM):')
+console.log(rsaKeyPair.publicKey.toPem())
+
+// Generate an ECDSA key pair using P-256 curve
+console.log('\n\nGenerating ECDSA P-256 key pair...')
+const ecKeyPair = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+
+console.log('EC Private Key (PEM):')
+console.log(ecKeyPair.privateKey.toPem())
+console.log('\nEC Public Key (PEM):')
+console.log(ecKeyPair.publicKey.toPem())
+
+// Generate an ECDSA key pair using P-384 curve
+console.log('\n\nGenerating ECDSA P-384 key pair...')
+const ecP384KeyPair = await KeyGen.generateEcPair({ namedCurve: 'P-384' })
+
+console.log('EC P-384 Private Key (PEM):')
+console.log(ecP384KeyPair.privateKey.toPem())
+
+// You can also extract the raw key objects
+const privateKey = rsaKeyPair.privateKey.getPrivateKey()
+console.log('\n\nRSA Private Key type:', privateKey.constructor.name)
+
+const ecPrivateKey = ecKeyPair.privateKey.getPrivateKey()
+console.log('EC Private Key type:', ecPrivateKey.constructor.name)

--- a/examples/010-certificate-signing-request.ts
+++ b/examples/010-certificate-signing-request.ts
@@ -1,0 +1,41 @@
+// Creating a Certificate Signing Request (CSR) / PKCS#10
+
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { CertificateRequest } from 'pki-lite/x509/CertificateRequest.js'
+
+// Generate a key pair
+console.log('Generating RSA key pair...')
+const keyPair = await KeyGen.generateRsaPair()
+console.log('✓ Key pair generated\n')
+
+// Build and sign the CSR
+const csr = await CertificateRequest.builder()
+    .setSubject('CN=example.com, O=Example Organization, C=US')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+    })
+    .addSubjectAltName('example.com', 'www.example.com')
+    .build()
+
+// Output the CSR in PEM format
+console.log('Certificate Signing Request (PEM):')
+console.log(csr.toPem())
+
+// You can also verify the CSR by parsing it back
+const parsedCsr = CertificateRequest.fromPem(csr.toPem())
+console.log('\n✓ CSR successfully created and parsed')
+console.log('Subject:', parsedCsr.requestInfo.subject.toString())
+console.log(
+    'Signature Algorithm:',
+    parsedCsr.signatureAlgorithm.algorithm.toString(),
+)
+console.log(
+    'Number of attributes:',
+    parsedCsr.requestInfo.attributes?.length ?? 0,
+)

--- a/examples/011-ca-certificate-issuance.ts
+++ b/examples/011-ca-certificate-issuance.ts
@@ -1,0 +1,96 @@
+// Creating a CA certificate and issuing end-entity certificates
+
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+
+console.log('=== Step 1: Generate CA Key Pair ===')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 4096 })
+console.log('✓ CA key pair generated')
+
+console.log('\n=== Step 2: Create CA Certificate (Self-Signed) ===')
+
+// Build and sign the CA certificate
+const caCertificate = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Organization, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 0) // CA with path length 0
+    .addKeyUsage({
+        keyCertSign: true, // Can sign certificates
+        cRLSign: true, // Can sign CRLs
+    })
+    .selfSign()
+
+console.log('✓ CA certificate created')
+console.log('  Subject:', caCertificate.tbsCertificate.subject.toString())
+console.log('  Serial:', caCertificate.tbsCertificate.serialNumber.toString())
+console.log(
+    '  Valid from:',
+    caCertificate.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    caCertificate.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+console.log('\n=== Step 3: Generate End-Entity Key Pair ===')
+const endEntityKeyPair = await KeyGen.generateRsaPair()
+console.log('✓ End-entity key pair generated')
+
+console.log('\n=== Step 4: Issue End-Entity Certificate ===')
+
+// Build and sign the end-entity certificate with the CA
+const endEntityCertificate = await Certificate.builder()
+    .setSubject('CN=example.com, O=Example Organization, C=US')
+    .setIssuer(caCertificate) // The CA certificate
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setIssuerPrivateKey(caKeyPair.privateKey) // Sign with CA's private key
+    .setValidityDays(365) // 1 year
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+        clientAuth: true,
+    })
+    .addSubjectAltName('example.com', 'www.example.com', '*.example.com')
+    .sign()
+
+console.log('✓ End-entity certificate issued')
+console.log(
+    '  Subject:',
+    endEntityCertificate.tbsCertificate.subject.toString(),
+)
+console.log('  Issuer:', endEntityCertificate.tbsCertificate.issuer.toString())
+console.log(
+    '  Serial:',
+    endEntityCertificate.tbsCertificate.serialNumber.toString(),
+)
+console.log(
+    '  Valid from:',
+    endEntityCertificate.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    endEntityCertificate.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+console.log('\n=== Step 5: Verify Certificate Chain ===')
+// Verify the signature on the end-entity certificate using the CA's public key
+const isValid = await endEntityCertificate.isIssuedBy(caCertificate)
+console.log('✓ Certificate chain verification:', isValid ? 'VALID' : 'INVALID')
+
+console.log('\n=== Certificates in PEM Format ===')
+console.log('\n--- CA Certificate ---')
+console.log(caCertificate.toPem())
+
+console.log('\n--- End-Entity Certificate ---')
+console.log(endEntityCertificate.toPem())
+
+console.log('\n--- End-Entity Private Key ---')
+console.log(endEntityKeyPair.privateKey.toPem())

--- a/examples/012-certificate-validation.ts
+++ b/examples/012-certificate-validation.ts
@@ -1,0 +1,212 @@
+// Certificate chain building and validation
+
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { CertificateValidator } from 'pki-lite/core/CertificateValidator.js'
+
+// For this example, you would typically load real certificates
+// Here we show how to use the validator with placeholder certificates
+
+console.log('=== Certificate Chain Validation Example ===\n')
+
+// Example 1: Load certificates from PEM strings
+const rootCertPem = `-----BEGIN CERTIFICATE-----
+{your root CA certificate here}
+-----END CERTIFICATE-----`
+
+const intermediateCertPem = `-----BEGIN CERTIFICATE-----
+{your intermediate CA certificate here}
+-----END CERTIFICATE-----`
+
+const endEntityCertPem = `-----BEGIN CERTIFICATE-----
+{your end-entity certificate here}
+-----END CERTIFICATE-----`
+
+// Parse the certificates
+const rootCert = Certificate.fromPem(rootCertPem)
+const intermediateCert = Certificate.fromPem(intermediateCertPem)
+const endEntityCert = Certificate.fromPem(endEntityCertPem)
+
+console.log('Loaded certificates:')
+console.log('  Root CA:', rootCert.tbsCertificate.subject.toString())
+console.log(
+    '  Intermediate CA:',
+    intermediateCert.tbsCertificate.subject.toString(),
+)
+console.log('  End Entity:', endEntityCert.tbsCertificate.subject.toString())
+
+console.log('\n=== Validation 1: Basic Certificate Validation ===')
+const validator = new CertificateValidator()
+
+// Validate just the end-entity certificate (without chain validation)
+const basicValidation = await validator.validate(endEntityCert, {
+    checkSignature: false, // Don't check signature without issuer
+})
+
+console.log('Validation Status:', basicValidation.status)
+console.log('Is Valid:', basicValidation.isValid)
+console.log('Messages:', basicValidation.messages.join(', '))
+console.log('Validated At:', basicValidation.validatedAt.toISOString())
+
+console.log('\n=== Validation 2: Certificate Chain Validation ===')
+
+// Validate the full certificate chain
+const chainValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    checkSignature: true,
+    enforceCAConstraints: true,
+    trustAnchors: [
+        {
+            certificate: rootCert,
+        },
+    ],
+    otherCertificates: [intermediateCert], // Intermediate certificates for chain building
+})
+
+console.log('Chain Validation Status:', chainValidation.status)
+console.log('Is Valid:', chainValidation.isValid)
+console.log('Messages:', chainValidation.messages.join(', '))
+
+if (chainValidation.chain) {
+    console.log('\nCertificate Chain:')
+    console.log('  Is Complete:', chainValidation.chain.isComplete)
+    console.log('  Chain Length:', chainValidation.chain.certificates.length)
+    chainValidation.chain.certificates.forEach((cert, index) => {
+        console.log(`  [${index}] ${cert.tbsCertificate.subject.toString()}`)
+    })
+}
+
+console.log('\nDiagnostics:')
+console.log(
+    '  Steps Performed:',
+    chainValidation.diagnostics.stepsPerformed.length,
+)
+chainValidation.diagnostics.stepsPerformed.forEach((step) => {
+    console.log(`    - ${step}`)
+})
+
+if (chainValidation.diagnostics.warnings.length > 0) {
+    console.log('  Warnings:', chainValidation.diagnostics.warnings.length)
+    chainValidation.diagnostics.warnings.forEach((warning) => {
+        console.log(`    ! ${warning}`)
+    })
+}
+
+console.log('\n=== Validation 3: With Custom Validation Time ===')
+
+// Validate with a specific date (useful for checking historical validity)
+const historicalDate = new Date('2023-06-01T00:00:00Z')
+const historicalValidation = await validator.validate(endEntityCert, {
+    validationTime: historicalDate,
+    timeTolerance: 300000, // 5 minutes tolerance in milliseconds
+})
+
+console.log('Historical Validation Status:', historicalValidation.status)
+console.log('Is Valid:', historicalValidation.isValid)
+console.log('Validation Time:', historicalDate.toISOString())
+
+console.log('\n=== Validation 4: With Revocation Checking (CRL) ===')
+
+// If you have CRLs available
+const crl = await endEntityCert.requestCrl()
+if (crl) {
+    const crlValidation = await validator.validate(
+        endEntityCert,
+        {
+            checkCRL: true,
+        },
+        {
+            crls: [crl],
+            issuerCertificate: intermediateCert,
+        },
+    )
+
+    console.log('CRL Validation Status:', crlValidation.status)
+    console.log('Is Valid:', crlValidation.isValid)
+    console.log('Revocation Status:')
+    console.log('  Is Revoked:', crlValidation.revocationStatus.isRevoked)
+    console.log('  Source:', crlValidation.revocationStatus.source)
+    if (crlValidation.revocationStatus.reason !== undefined) {
+        console.log('  Reason:', crlValidation.revocationStatus.reason)
+    }
+} else {
+    console.log('No CRL available for this certificate')
+}
+
+console.log('\n=== Validation 5: With Name Constraints ===')
+
+// Validate with name constraints (if the CA has name constraints)
+const nameConstraintsValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    validateNameConstraints: true,
+    trustAnchors: [
+        {
+            certificate: rootCert,
+            // nameConstraints: customNameConstraints, // Add custom constraints if needed
+        },
+    ],
+    otherCertificates: [intermediateCert],
+})
+
+console.log(
+    'Name Constraints Validation Status:',
+    nameConstraintsValidation.status,
+)
+console.log('Is Valid:', nameConstraintsValidation.isValid)
+
+console.log('\n=== Validation 6: Policy Validation ===')
+
+// Validate with required policies
+const policyValidation = await validator.validate(endEntityCert, {
+    validateChain: true,
+    validatePolicies: true,
+    requiredPolicies: ['1.3.6.1.4.1.99999.1.2.3'], // Example policy OID
+    trustAnchors: [
+        {
+            certificate: rootCert,
+        },
+    ],
+    otherCertificates: [intermediateCert],
+})
+
+console.log('Policy Validation Status:', policyValidation.status)
+console.log('Is Valid:', policyValidation.isValid)
+if (policyValidation.policyResult) {
+    console.log('Policy Result:')
+    console.log('  Is Valid:', policyValidation.policyResult.isValid)
+    console.log(
+        '  Valid Policies:',
+        policyValidation.policyResult.validPolicies,
+    )
+    console.log('  Violations:', policyValidation.policyResult.violations)
+}
+
+console.log('\n=== Certificate Information ===')
+
+// Extract useful information from a certificate
+console.log('\nEnd Entity Certificate Details:')
+console.log('  Version:', endEntityCert.tbsCertificate.version + 1) // Version is 0-indexed
+console.log(
+    '  Serial Number:',
+    endEntityCert.tbsCertificate.serialNumber.toString(),
+)
+console.log('  Subject:', endEntityCert.tbsCertificate.subject.toString())
+console.log('  Issuer:', endEntityCert.tbsCertificate.issuer.toString())
+console.log(
+    '  Not Before:',
+    endEntityCert.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Not After:',
+    endEntityCert.tbsCertificate.validity.notAfter.toISOString(),
+)
+console.log(
+    '  Signature Algorithm:',
+    endEntityCert.signatureAlgorithm.algorithm.toString(),
+)
+
+if (endEntityCert.tbsCertificate.extensions) {
+    console.log('  Extensions:', endEntityCert.tbsCertificate.extensions.length)
+    endEntityCert.tbsCertificate.extensions.forEach((ext) => {
+        console.log(`    - ${ext.extnID.value} (Critical: ${ext.critical})`)
+    })
+}

--- a/examples/012-certificate-validation.ts
+++ b/examples/012-certificate-validation.ts
@@ -1,30 +1,57 @@
 // Certificate chain building and validation
 
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
 import { Certificate } from 'pki-lite/x509/Certificate.js'
 import { CertificateValidator } from 'pki-lite/core/CertificateValidator.js'
 
-// For this example, you would typically load real certificates
-// Here we show how to use the validator with placeholder certificates
-
 console.log('=== Certificate Chain Validation Example ===\n')
 
-// Example 1: Load certificates from PEM strings
-const rootCertPem = `-----BEGIN CERTIFICATE-----
-{your root CA certificate here}
------END CERTIFICATE-----`
+// Generate keys and create a certificate chain for demonstration
+console.log('Setting up certificate chain...')
 
-const intermediateCertPem = `-----BEGIN CERTIFICATE-----
-{your intermediate CA certificate here}
------END CERTIFICATE-----`
+// Generate keys for each level
+const rootKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const intermediateKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const endEntityKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
 
-const endEntityCertPem = `-----BEGIN CERTIFICATE-----
-{your end-entity certificate here}
------END CERTIFICATE-----`
+// Create root CA certificate
+const rootCert = await Certificate.builder()
+    .setSubject('CN=Root CA, O=Example Root CA, C=US')
+    .setPublicKey(rootKeyPair.publicKey)
+    .setPrivateKey(rootKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2) // CA with path length 2
+    .addKeyUsage({ keyCertSign: true, cRLSign: true })
+    .selfSign()
 
-// Parse the certificates
-const rootCert = Certificate.fromPem(rootCertPem)
-const intermediateCert = Certificate.fromPem(intermediateCertPem)
-const endEntityCert = Certificate.fromPem(endEntityCertPem)
+// Create intermediate CA certificate signed by root
+const intermediateCert = await Certificate.builder()
+    .setSubject('CN=Intermediate CA, O=Example Intermediate CA, C=US')
+    .setIssuer(rootCert.tbsCertificate.subject)
+    .setPublicKey(intermediateKeyPair.publicKey)
+    .setPrivateKey(rootKeyPair.privateKey) // Signed by root
+    .setValidityDays(1825) // 5 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 0) // CA with path length 0
+    .addKeyUsage({ keyCertSign: true, cRLSign: true })
+    .build()
+
+// Create end-entity certificate signed by intermediate
+const endEntityCert = await Certificate.builder()
+    .setSubject('CN=www.example.com, O=Example Corp, C=US')
+    .setIssuer(intermediateCert.tbsCertificate.subject)
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setPrivateKey(intermediateKeyPair.privateKey) // Signed by intermediate
+    .setValidityDays(365) // 1 year
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .addKeyUsage({ digitalSignature: true, keyEncipherment: true })
+    .addExtendedKeyUsage({ serverAuth: true })
+    .addSubjectAltName('www.example.com', 'example.com')
+    .build()
+
+console.log('✓ Certificate chain created\n')
 
 console.log('Loaded certificates:')
 console.log('  Root CA:', rootCert.tbsCertificate.subject.toString())

--- a/examples/013-certificate-builder.ts
+++ b/examples/013-certificate-builder.ts
@@ -1,0 +1,173 @@
+// Using the Certificate Builder for flexible certificate creation
+
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { GeneralName } from 'pki-lite/x509/GeneralName.js'
+
+console.log('=== Certificate Builder Examples ===\n')
+
+// Generate keys for the examples
+console.log('Generating key pairs...')
+const keyPair1 = await KeyGen.generateRsaPair({ keySize: 2048 })
+const keyPair2 = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+console.log('✓ Key pairs generated\n')
+
+// Example 1: Basic self-signed certificate with minimal configuration
+console.log('=== Example 1: Basic Self-Signed Certificate ===')
+const basicCert = await Certificate.builder()
+    .setSubject('CN=Basic Certificate')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Basic certificate created')
+console.log('  Subject:', basicCert.tbsCertificate.subject.toString())
+console.log('  Serial:', basicCert.tbsCertificate.serialNumber.toString())
+
+// Example 2: Certificate with specific validity period
+console.log('\n=== Example 2: Certificate with Specific Validity Period ===')
+const startDate = new Date('2024-01-01T00:00:00Z')
+const endDate = new Date('2025-01-01T00:00:00Z')
+
+const timedCert = await Certificate.builder()
+    .setSubject('CN=Timed Certificate, O=Example Org')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityPeriod(startDate, endDate)
+    .generateSerialNumber()
+    .selfSign()
+
+console.log('✓ Timed certificate created')
+console.log(
+    '  Valid from:',
+    timedCert.tbsCertificate.validity.notBefore.toISOString(),
+)
+console.log(
+    '  Valid until:',
+    timedCert.tbsCertificate.validity.notAfter.toISOString(),
+)
+
+// Example 3: Server certificate with extensions using builder helpers
+console.log('\n=== Example 3: Server Certificate with Extensions ===')
+const serverCert = await Certificate.builder()
+    .setSubject('CN=api.example.com, O=Example Organization, C=US')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        serverAuth: true,
+        clientAuth: true,
+    })
+    .addSubjectAltName(
+        'api.example.com',
+        '*.api.example.com',
+        new GeneralName.rfc822Name({ value: 'admin@example.com' }),
+    )
+    .addBasicConstraints(false) // Not a CA
+    .selfSign()
+
+console.log('✓ Server certificate created')
+console.log('  Extensions:', serverCert.tbsCertificate.extensions?.length ?? 0)
+
+// Example 4: EC certificate with specific algorithm
+console.log('\n=== Example 4: EC Certificate with Custom Algorithm ===')
+const ecCert = await Certificate.builder()
+    .setSubject('CN=EC Certificate')
+    .setPublicKey(keyPair2.publicKey)
+    .setPrivateKey(keyPair2.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .setAlgorithm({
+        type: 'ECDSA',
+        params: { namedCurve: 'P-256', hash: 'SHA-256' },
+    })
+    .selfSign()
+
+console.log('✓ EC certificate created')
+console.log('  Algorithm:', ecCert.signatureAlgorithm.algorithm.toString())
+
+// Example 5: CA certificate with path length constraint
+console.log('\n=== Example 5: CA Certificate with Path Length Constraint ===')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 4096 })
+
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example Root CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650) // 10 years
+    .generateSerialNumber()
+    .addBasicConstraints(true, 1) // CA with path length 1
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .setVersion(2) // X.509 v3
+    .selfSign()
+
+console.log('✓ CA certificate created')
+console.log('  Subject:', caCert.tbsCertificate.subject.toString())
+console.log('  Is CA: true')
+console.log('  Path Length Constraint: 1')
+
+// Example 6: Issuing a certificate from the CA
+console.log('\n=== Example 6: Certificate Issued by CA ===')
+const userKeyPair = await KeyGen.generateRsaPair()
+
+const issuedCert = await Certificate.builder()
+    .setSubject('CN=John Doe, O=Example Org, C=US')
+    .setIssuer(caCert) // Set the CA as issuer
+    .setPublicKey(userKeyPair.publicKey)
+    .setIssuerPrivateKey(caKeyPair.privateKey) // Use CA's private key to sign
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addBasicConstraints(false) // Not a CA
+    .sign()
+
+console.log('✓ User certificate issued by CA')
+console.log('  Subject:', issuedCert.tbsCertificate.subject.toString())
+console.log('  Issuer:', issuedCert.tbsCertificate.issuer.toString())
+
+// Verify the issued certificate
+const isValid = await issuedCert.isIssuedBy(caCert)
+console.log('  Signature valid:', isValid)
+
+// Example 7: Custom serial number
+console.log('\n=== Example 7: Certificate with Custom Serial Number ===')
+const customSerial = new Uint8Array([
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+])
+
+const customSerialCert = await Certificate.builder()
+    .setSubject('CN=Custom Serial')
+    .setPublicKey(keyPair1.publicKey)
+    .setPrivateKey(keyPair1.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(customSerial)
+    .selfSign()
+
+console.log('✓ Certificate with custom serial created')
+console.log(
+    '  Serial:',
+    customSerialCert.tbsCertificate.serialNumber.toString(),
+)
+
+console.log('\n=== All Examples Completed ===')
+console.log('\nCertificate Builder Features:')
+console.log('  • Fluent API for creating certificates')
+console.log('  • Helper methods for common extensions:')
+console.log('    - addKeyUsage() - Key usage flags')
+console.log('    - addExtendedKeyUsage() - Extended key usage purposes')
+console.log('    - addBasicConstraints() - CA status and path length')
+console.log('    - addSubjectAltName() - Alternative names')
+console.log('  • Support for both self-signed and CA-signed certificates')
+console.log('\nExport certificates using:')
+console.log('  • certificate.toPem() - Export as PEM')
+console.log('  • certificate.toDer() - Export as DER')
+console.log('  • certificate.toString() - View ASN.1 structure')

--- a/examples/014-pfx-builder.ts
+++ b/examples/014-pfx-builder.ts
@@ -1,0 +1,141 @@
+// Building a PKCS#12 (PFX) file with certificate and private key
+
+import { PFX } from 'pki-lite/pkcs12/PFX.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+
+console.log('=== PFX Builder Examples ===\n')
+
+// Generate a key pair for the examples
+console.log('Generating RSA key pair...')
+const keyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+console.log('✓ Key pair generated\n')
+
+// Create a self-signed certificate
+console.log('Creating self-signed certificate...')
+const certificate = await Certificate.builder()
+    .setSubject('CN=Example User, O=Example Org, C=US')
+    .setPublicKey(keyPair.publicKey)
+    .setPrivateKey(keyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .selfSign()
+console.log('✓ Certificate created\n')
+
+// Example 1: Basic PFX with certificate and private key
+console.log('=== Example 1: Basic PFX with Certificate and Private Key ===')
+const basicPfx = await PFX.builder()
+    .addCertificate(certificate)
+    .addPrivateKey(keyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .build()
+
+console.log('✓ PFX created')
+console.log('  Has MAC data:', !!basicPfx.macData)
+console.log('  PFX size:', basicPfx.toDer().length, 'bytes\n')
+
+// Example 2: PFX with friendly name
+console.log('=== Example 2: PFX with Friendly Name ===')
+const namedPfx = await PFX.builder()
+    .addCertificate(certificate)
+    .addPrivateKey(keyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .setFriendlyName('My Digital Identity')
+    .setIterations(100000) // Higher iterations for better security
+    .build()
+
+console.log('✓ PFX with friendly name created')
+console.log('  Iterations:', namedPfx.macData?.iterations)
+console.log('  PFX size:', namedPfx.toDer().length, 'bytes\n')
+
+// Example 3: PFX with certificate chain
+console.log('=== Example 3: PFX with Certificate Chain ===')
+
+// Generate a CA key pair
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+
+// Create a CA certificate
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2) // CA with pathLen=2
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+
+// Create an end-entity certificate signed by CA
+const endEntityKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const endEntityCert = await Certificate.builder()
+    .setSubject('CN=End Entity, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(endEntityKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey) // Signed by CA
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .addExtendedKeyUsage({
+        clientAuth: true,
+        emailProtection: true,
+    })
+    .build()
+
+// Build PFX with certificate chain
+const chainPfx = await PFX.builder()
+    .addCertificate(endEntityCert) // End entity cert first
+    .addCertificate(caCert) // CA cert for chain
+    .addPrivateKey(endEntityKeyPair.privateKey)
+    .setPassword('mySecurePassword123')
+    .setFriendlyName('My Identity with Chain')
+    .setIterations(100000)
+    .build()
+
+console.log('✓ PFX with certificate chain created')
+console.log('  Certificates in chain: 2')
+console.log('  PFX size:', chainPfx.toDer().length, 'bytes\n')
+
+// Example 4: Export and verify PFX
+console.log('=== Example 4: Export and Verify PFX ===')
+
+// Export to PEM format
+const pfxPem = basicPfx.toPem()
+console.log('✓ PFX exported to PEM format')
+console.log('  PEM preview:', pfxPem.substring(0, 50) + '...\n')
+
+// Verify by parsing and extracting contents
+const password = 'mySecurePassword123'
+const parsedPfx = PFX.fromPem(pfxPem)
+
+const extractedCerts = await parsedPfx.getX509Certificates(password)
+const extractedKeys = await parsedPfx.getPrivateKeys(password)
+
+console.log('✓ PFX verified successfully')
+console.log('  Extracted certificates:', extractedCerts.length)
+console.log('  Extracted private keys:', extractedKeys.length)
+console.log(
+    '  Certificate subject:',
+    extractedCerts[0].tbsCertificate.subject.toString(),
+)
+
+// Example 5: Using PFX.create() shorthand
+console.log('\n=== Example 5: Using PFX.create() Shorthand ===')
+const shorthandPfx = await PFX.create({
+    certificates: [certificate],
+    privateKeys: [keyPair.privateKey],
+    password: 'mySecurePassword123',
+    friendlyName: 'Quick Identity',
+})
+
+console.log('✓ PFX created using shorthand method')
+console.log('  PFX size:', shorthandPfx.toDer().length, 'bytes')

--- a/examples/015-encrypted-data-builder.ts
+++ b/examples/015-encrypted-data-builder.ts
@@ -1,0 +1,174 @@
+// Building encrypted data using the EncryptedData builder
+
+import { EncryptedData } from 'pki-lite/pkcs7/EncryptedData.js'
+import { OIDs } from 'pki-lite/core/OIDs.js'
+import { getCryptoProvider } from 'pki-lite/core/crypto/provider.js'
+
+console.log('=== EncryptedData Builder Examples ===\n')
+
+const secretMessage = new TextEncoder().encode(
+    'This is a secret message that needs to be encrypted!',
+)
+const password = 'mySecurePassword123'
+
+// Example 1: Basic encryption with default settings (PBES2)
+console.log('=== Example 1: Basic Encryption with Default Settings ===')
+const basicEncrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .build()
+
+console.log('✓ Data encrypted with default PBES2 algorithm')
+console.log('  Version:', basicEncrypted.version)
+console.log(
+    '  Content type:',
+    basicEncrypted.encryptedContentInfo.contentType.value,
+)
+console.log(
+    '  Encrypted size:',
+    basicEncrypted.encryptedContentInfo.encryptedContent?.bytes.length,
+    'bytes',
+)
+console.log(
+    '  Algorithm:',
+    basicEncrypted.encryptedContentInfo.contentEncryptionAlgorithm.friendlyName,
+)
+
+// Decrypt to verify
+const provider = getCryptoProvider()
+const algorithm1 = provider.toSymmetricEncryptionAlgorithmParams(
+    basicEncrypted.encryptedContentInfo.contentEncryptionAlgorithm,
+)
+const decrypted1 = await provider.decryptSymmetric(
+    basicEncrypted.encryptedContentInfo.encryptedContent!.bytes,
+    password as any, // Type definitions need updating to accept string
+    algorithm1,
+)
+console.log('✓ Decrypted successfully:', new TextDecoder().decode(decrypted1))
+console.log()
+
+// Example 2: Encryption with custom PBKDF2 iterations
+console.log('=== Example 2: Custom Iterations for PBKDF2 ===')
+const customIterations = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 100000, // Higher security
+                    hash: 'SHA-256',
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_256_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted with 100,000 PBKDF2 iterations')
+console.log(
+    '  Algorithm:',
+    customIterations.encryptedContentInfo.contentEncryptionAlgorithm
+        .friendlyName,
+)
+console.log()
+
+// Example 3: Encryption with SHA-512 hash
+console.log('=== Example 3: Using SHA-512 for Key Derivation ===')
+const sha512Encrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 50000,
+                    hash: 'SHA-512', // More secure hash
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_256_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted using SHA-512 for key derivation')
+console.log(
+    '  Algorithm:',
+    sha512Encrypted.encryptedContentInfo.contentEncryptionAlgorithm
+        .friendlyName,
+)
+console.log()
+
+// Example 4: Encryption with AES-128 (smaller key size)
+console.log('=== Example 4: Using AES-128-CBC ===')
+const aes128Encrypted = await EncryptedData.builder()
+    .setContentType('DATA')
+    .setData(secretMessage)
+    .setPassword(password)
+    .setAlgorithm({
+        type: 'PBES2',
+        params: {
+            derivationAlgorithm: {
+                type: 'PBKDF2',
+                params: {
+                    salt: crypto.getRandomValues(new Uint8Array(16)),
+                    iterationCount: 10000,
+                    hash: 'SHA-256',
+                },
+            },
+            encryptionAlgorithm: {
+                type: 'AES_128_CBC',
+                params: {
+                    nonce: crypto.getRandomValues(new Uint8Array(16)),
+                },
+            },
+        },
+    })
+    .build()
+
+console.log('✓ Data encrypted with AES-128-CBC')
+console.log()
+
+// Example 5: Using EncryptedData.create() shorthand
+console.log('=== Example 5: Using EncryptedData.create() Shorthand ===')
+const shorthand = await EncryptedData.create({
+    contentType: 'DATA',
+    data: secretMessage,
+    password,
+    iterations: 50000,
+})
+
+console.log('✓ Data encrypted using shorthand method')
+console.log('  Encrypted size:', shorthand.toDer().length, 'bytes')
+console.log()
+
+// Example 6: Export to DER and convert to CMS
+console.log('=== Example 6: Export and Convert to CMS ===')
+const der = basicEncrypted.toDer()
+console.log('✓ Encrypted data exported to DER')
+console.log('  DER size:', der.length, 'bytes')
+
+// Convert to CMS ContentInfo
+const cms = basicEncrypted.asCms()
+console.log('✓ Converted to CMS ContentInfo')
+console.log('  Content type:', cms.contentType.value)
+console.log('  CMS size:', cms.toDer().length, 'bytes')

--- a/examples/016-crl-builder.ts
+++ b/examples/016-crl-builder.ts
@@ -1,0 +1,183 @@
+// Building a Certificate Revocation List (CRL) using the CertificateList builder
+
+import { CertificateList } from 'pki-lite/x509/CertificateList.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { Extension } from 'pki-lite/x509/Extension.js'
+import { OIDs } from 'pki-lite/core/OIDs.js'
+
+console.log('=== CRL Builder Examples ===\n')
+
+// First, create a CA certificate and key pair
+console.log('Setting up CA...')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const caCert = await Certificate.builder()
+    .setSubject('CN=Example CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2)
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+console.log('✓ CA certificate created\n')
+
+// Create some end-entity certificates to revoke
+console.log('Creating certificates to revoke...')
+const cert1KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert1 = await Certificate.builder()
+    .setSubject('CN=User 1, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert1KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(1001)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .build()
+
+const cert2KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert2 = await Certificate.builder()
+    .setSubject('CN=User 2, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert2KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(1002)
+    .addKeyUsage({
+        digitalSignature: true,
+        keyEncipherment: true,
+    })
+    .build()
+
+console.log('✓ Test certificates created\n')
+
+// Example 1: Basic CRL with revoked certificates
+console.log('=== Example 1: Basic CRL with Revoked Certificates ===')
+const basicCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setThisUpdate(new Date())
+    .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)) // 30 days
+    .addRevokedCertificate({
+        serialNumber: 1001,
+        revocationDate: new Date(),
+    })
+    .addRevokedCertificate({
+        serialNumber: 1002,
+        revocationDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // 7 days ago
+    })
+    .build()
+
+console.log('✓ Basic CRL created')
+console.log('  Issuer:', basicCrl.tbsCertList.issuer.toString())
+console.log('  This Update:', basicCrl.tbsCertList.thisUpdate)
+console.log('  Next Update:', basicCrl.tbsCertList.nextUpdate)
+console.log(
+    '  Revoked Certificates:',
+    basicCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log('  CRL size:', basicCrl.toDer().length, 'bytes\n')
+
+// Example 2: Revoking certificates by reference
+console.log('=== Example 2: Revoking Certificates by Reference ===')
+const referenceCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .revokeCertificate(cert1) // Revokes using current time
+    .revokeCertificate(cert2, new Date(Date.now() - 14 * 24 * 60 * 60 * 1000)) // 14 days ago
+    .build()
+
+console.log('✓ CRL created by revoking certificate references')
+console.log(
+    '  Revoked Certificates:',
+    referenceCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log()
+
+// Example 3: CRL with CRL Number extension
+console.log('=== Example 3: CRL with CRL Number Extension ===')
+const crlNumberExtension = new Extension({
+    extnID: OIDs.EXTENSION.CRL_NUMBER,
+    critical: false,
+    extnValue: new Uint8Array([0x02, 0x01, 0x01]), // Integer 1 (ASN.1 DER encoded)
+})
+
+const numberedCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .addExtension(crlNumberExtension)
+    .revokeCertificate(cert1)
+    .build()
+
+console.log('✓ CRL with CRL Number extension created')
+console.log('  Extensions:', numberedCrl.tbsCertList.extensions?.length || 0)
+console.log(
+    '  CRL version:',
+    numberedCrl.tbsCertList.version === 1 ? 'v2' : 'v1',
+)
+console.log()
+
+// Example 4: Empty CRL (no revoked certificates)
+console.log('=== Example 4: Empty CRL ===')
+const emptyCrl = await CertificateList.builder()
+    .setIssuerFromCertificate(caCert)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setThisUpdate(new Date())
+    .setNextUpdate(new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)) // 7 days
+    .build()
+
+console.log('✓ Empty CRL created (no revoked certificates)')
+console.log(
+    '  Revoked Certificates:',
+    emptyCrl.tbsCertList.revokedCertificates?.length || 0,
+)
+console.log('  CRL version:', emptyCrl.tbsCertList.version === 1 ? 'v2' : 'v1')
+console.log()
+
+// Example 5: Export and parse CRL
+console.log('=== Example 5: Export and Parse CRL ===')
+
+// Export to PEM
+const crlPem = basicCrl.toPem()
+console.log('✓ CRL exported to PEM format')
+console.log('  PEM preview:', crlPem.substring(0, 50) + '...')
+
+// Parse back from PEM
+const parsedCrl = CertificateList.fromPem(crlPem)
+console.log('✓ CRL parsed from PEM')
+console.log(
+    '  Issuer matches:',
+    parsedCrl.tbsCertList.issuer.toString() ===
+        basicCrl.tbsCertList.issuer.toString(),
+)
+console.log(
+    '  Revoked count matches:',
+    parsedCrl.tbsCertList.revokedCertificates?.length ===
+        basicCrl.tbsCertList.revokedCertificates?.length,
+)
+console.log()
+
+// Example 6: Checking if a certificate is revoked
+console.log('=== Example 6: Checking Revocation Status ===')
+const serialToCheck = cert1.tbsCertificate.serialNumber.toString()
+const isRevoked = basicCrl.tbsCertList.revokedCertificates?.some(
+    (revoked) => revoked.userCertificate.toString() === serialToCheck,
+)
+
+console.log(
+    `Certificate with serial ${serialToCheck}:`,
+    isRevoked ? 'REVOKED' : 'Valid',
+)
+
+if (isRevoked) {
+    const revokedEntry = basicCrl.tbsCertList.revokedCertificates?.find(
+        (revoked) => revoked.userCertificate.toString() === serialToCheck,
+    )
+    console.log('  Revocation Date:', revokedEntry?.revocationDate)
+}

--- a/examples/017-ocsp-response-builder.ts
+++ b/examples/017-ocsp-response-builder.ts
@@ -1,0 +1,221 @@
+// Building OCSP responses using the OCSPResponse builder
+
+import { OCSPResponse } from 'pki-lite/ocsp/OCSPResponse.js'
+import { CertID } from 'pki-lite/ocsp/CertID.js'
+import { KeyGen } from 'pki-lite/core/KeyGen.js'
+import { Certificate } from 'pki-lite/x509/Certificate.js'
+import { OCSPResponseStatus } from 'pki-lite/ocsp/OCSPResponseStatus.js'
+
+console.log('=== OCSP Response Builder Examples ===\n')
+
+// Setup: Create CA and certificates
+console.log('Setting up CA and certificates...')
+const caKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const caCert = await Certificate.builder()
+    .setSubject('CN=OCSP CA, O=Example Org, C=US')
+    .setPublicKey(caKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(3650)
+    .generateSerialNumber()
+    .addBasicConstraints(true, 2)
+    .addKeyUsage({
+        keyCertSign: true,
+        cRLSign: true,
+    })
+    .selfSign()
+
+// Create an OCSP responder key
+const responderKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const responderCert = await Certificate.builder()
+    .setSubject('CN=OCSP Responder, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(responderKeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .generateSerialNumber()
+    .addKeyUsage({
+        digitalSignature: true,
+    })
+    .addExtendedKeyUsage({
+        ocspSigning: true,
+    })
+    .build()
+
+// Create some end-entity certificates
+const cert1KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert1 = await Certificate.builder()
+    .setSubject('CN=User 1, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert1KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(2001)
+    .build()
+
+const cert2KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+const cert2 = await Certificate.builder()
+    .setSubject('CN=User 2, O=Example Org, C=US')
+    .setIssuer(caCert.tbsCertificate.subject)
+    .setPublicKey(cert2KeyPair.publicKey)
+    .setPrivateKey(caKeyPair.privateKey)
+    .setValidityDays(365)
+    .setSerialNumber(2002)
+    .build()
+
+console.log('✓ Setup complete\n')
+
+// Example 1: Basic OCSP response with good status (using Certificate directly)
+console.log('=== Example 1: Basic OCSP Response (Good Status) ===')
+
+const goodResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good') // Pass issuer and certificate!
+    .build()
+
+console.log('✓ OCSP response created with good status')
+console.log('  Response Status:', goodResponse.responseStatus.value)
+const basicResp1 = goodResponse.getBasicOCSPResponse()
+console.log('  Responses:', basicResp1.tbsResponseData.responses.length)
+console.log(
+    '  Certificate Status:',
+    basicResp1.tbsResponseData.responses[0].certStatus.status,
+)
+console.log('  Response size:', goodResponse.toDer().length, 'bytes\n')
+
+// Example 2: OCSP response with revoked status
+console.log('=== Example 2: OCSP Response with Revoked Status ===')
+const revocationDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) // 7 days ago
+
+const revokedResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert2, 'revoked', {
+        revocationTime: revocationDate,
+        revocationReason: 0, // unspecified reason
+    })
+    .build()
+
+console.log('✓ OCSP response created with revoked status')
+const basicResp2 = revokedResponse.getBasicOCSPResponse()
+console.log(
+    '  Certificate Status:',
+    basicResp2.tbsResponseData.responses[0].certStatus.status,
+)
+console.log(
+    '  Revocation Time:',
+    basicResp2.tbsResponseData.responses[0].certStatus.revocationTime,
+)
+console.log()
+
+// Example 3: Multiple certificate responses in one OCSP response
+console.log('=== Example 3: Multiple Certificate Responses ===')
+const multiResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good') // Add multiple responses!
+    .addResponse(caCert, cert2, 'revoked', {
+        revocationTime: revocationDate,
+        revocationReason: 0,
+    })
+    .build()
+
+console.log('✓ OCSP response with multiple certificates created')
+const basicResp3 = multiResponse.getBasicOCSPResponse()
+console.log('  Total responses:', basicResp3.tbsResponseData.responses.length)
+console.log(
+    '  Response 1 status:',
+    basicResp3.tbsResponseData.responses[0].certStatus.status,
+)
+console.log(
+    '  Response 2 status:',
+    basicResp3.tbsResponseData.responses[1].certStatus.status,
+)
+console.log()
+
+// Example 4: OCSP response with custom validity period
+console.log('=== Example 4: Custom Validity Period ===')
+const now = new Date()
+const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000)
+const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+
+const customValidityResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .setProducedAt(now)
+    .addResponse(caCert, cert1, 'good', {
+        thisUpdate: tomorrow,
+        nextUpdate: nextWeek,
+    })
+    .build()
+
+console.log('✓ OCSP response with custom validity created')
+const basicResp4 = customValidityResponse.getBasicOCSPResponse()
+console.log('  Produced At:', basicResp4.tbsResponseData.producedAt)
+console.log(
+    '  This Update:',
+    basicResp4.tbsResponseData.responses[0].thisUpdate.time,
+)
+console.log(
+    '  Next Update:',
+    basicResp4.tbsResponseData.responses[0].nextUpdate?.time,
+)
+console.log()
+
+// Example 5: OCSP response with responder certificate included
+console.log('=== Example 5: Including Responder Certificate ===')
+const withCertResponse = await OCSPResponse.builder()
+    .setResponderFromCertificate(responderCert)
+    .setPrivateKey(responderKeyPair.privateKey)
+    .addResponse(caCert, cert1, 'good')
+    .addCertificate(responderCert) // Include responder cert for validation
+    .build()
+
+console.log('✓ OCSP response with responder certificate created')
+const basicResp5 = withCertResponse.getBasicOCSPResponse()
+console.log('  Included certificates:', basicResp5.certs?.length || 0)
+if (basicResp5.certs && basicResp5.certs.length > 0) {
+    console.log(
+        '  Responder cert subject:',
+        basicResp5.certs[0].tbsCertificate.subject.toString(),
+    )
+}
+console.log()
+
+// Example 6: Error response (no signature required)
+console.log('=== Example 6: Error Response ===')
+const errorResponse = await OCSPResponse.builder()
+    .setResponseStatus(OCSPResponseStatus.malformedRequest)
+    .build()
+
+console.log('✓ Error response created')
+console.log('  Response Status:', errorResponse.responseStatus.value)
+console.log('  Has response bytes:', !!errorResponse.responseBytes)
+console.log()
+
+// Example 7: Using OCSPResponse.forCertificate() shorthand
+console.log('=== Example 7: Using forCertificate() Shorthand ===')
+const shorthandResponse = await OCSPResponse.forCertificate({
+    issuerCertificate: caCert,
+    subjectCertificate: cert1,
+    privateKey: responderKeyPair.privateKey,
+    responderID: responderCert.tbsCertificate.subject,
+})
+
+console.log('✓ OCSP response created using shorthand method')
+console.log('  Response Status:', shorthandResponse.responseStatus.value)
+console.log('  Response size:', shorthandResponse.toDer().length, 'bytes')
+console.log()
+
+// Example 8: Export and parse OCSP response
+console.log('=== Example 8: Export and Parse OCSP Response ===')
+const der = goodResponse.toDer()
+console.log('✓ OCSP response exported to DER')
+console.log('  DER size:', der.length, 'bytes')
+
+const parsed = OCSPResponse.fromDer(der)
+console.log('✓ OCSP response parsed from DER')
+console.log(
+    '  Status matches:',
+    parsed.responseStatus.value === goodResponse.responseStatus.value,
+)

--- a/packages/pki-lite/src/algorithms/AlgorithmIdentifier.ts
+++ b/packages/pki-lite/src/algorithms/AlgorithmIdentifier.ts
@@ -268,6 +268,18 @@ export class DigestAlgorithmIdentifier extends AlgorithmIdentifier {
         )
     }
 
+    async hmac(
+        key: Uint8Array<ArrayBuffer>,
+        data: Uint8Array<ArrayBuffer> | PkiBase,
+    ): Promise<Uint8Array<ArrayBuffer>> {
+        const crypto = getCryptoProvider()
+        return await crypto.hmac(
+            key,
+            data instanceof Uint8Array ? data : data.toDer(),
+            this.toHashAlgorithm(),
+        )
+    }
+
     static fromAsn1(asn1: Asn1BaseBlock): DigestAlgorithmIdentifier {
         const algId = AlgorithmIdentifier.fromAsn1(asn1)
         return new DigestAlgorithmIdentifier({
@@ -282,6 +294,42 @@ export class DigestAlgorithmIdentifier extends AlgorithmIdentifier {
 
     toHashAlgorithm(): HashAlgorithm {
         return getCryptoProvider().toHashAlgorithm(this)
+    }
+
+    /**
+     * Returns the output length in bytes for this hash algorithm.
+     */
+    getOutputBytes(): number {
+        const hash = this.toHashAlgorithm()
+        switch (hash) {
+            case 'SHA-1':
+                return 20
+            case 'SHA-256':
+                return 32
+            case 'SHA-384':
+                return 48
+            case 'SHA-512':
+                return 64
+            default:
+                throw new Error(`Unsupported hash algorithm: ${hash}`)
+        }
+    }
+
+    /**
+     * Returns the block size in bytes for this hash algorithm.
+     */
+    getBlockBytes(): number {
+        const hash = this.toHashAlgorithm()
+        switch (hash) {
+            case 'SHA-1':
+            case 'SHA-256':
+                return 64
+            case 'SHA-384':
+            case 'SHA-512':
+                return 128
+            default:
+                throw new Error(`Unsupported hash algorithm: ${hash}`)
+        }
     }
 }
 

--- a/packages/pki-lite/src/asn1/BMPString.test.ts
+++ b/packages/pki-lite/src/asn1/BMPString.test.ts
@@ -10,13 +10,18 @@ describe('BMPString', () => {
         expect(bmpString).toBeInstanceOf(BMPString)
         expect(bmpString.toString()).toEqual(testString)
 
-        // Should encode as UTF-8 bytes
-        const expectedBytes = new TextEncoder().encode(testString)
-        expect(bmpString.bytes).toEqual(expectedBytes)
+        // Should encode as UTF-16BE bytes (2 bytes per character)
+        expect(bmpString.bytes.length).toEqual(testString.length * 2)
+        // First character 'H' = 0x0048 in UTF-16BE
+        expect(bmpString.bytes[0]).toEqual(0x00)
+        expect(bmpString.bytes[1]).toEqual(0x48)
     })
 
     test('should create BMPString from Uint8Array<ArrayBuffer>', () => {
-        const bytes = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]) // "Hello"
+        // UTF-16BE for "Hello": 00 48 00 65 00 6C 00 6C 00 6F
+        const bytes = new Uint8Array([
+            0x00, 0x48, 0x00, 0x65, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x6f,
+        ])
         const bmpString = new BMPString({ value: bytes })
 
         expect(bmpString.bytes).toEqual(bytes)
@@ -37,9 +42,8 @@ describe('BMPString', () => {
 
         expect(bmpString.toString()).toEqual(unicodeString)
 
-        // Verify UTF-8 encoding
-        const expectedBytes = new TextEncoder().encode(unicodeString)
-        expect(bmpString.bytes).toEqual(expectedBytes)
+        // Verify UTF-16BE encoding (2 bytes per code unit)
+        expect(bmpString.bytes.length).toEqual(unicodeString.length * 2)
     })
 
     test('should handle empty string', () => {

--- a/packages/pki-lite/src/asn1/BMPString.ts
+++ b/packages/pki-lite/src/asn1/BMPString.ts
@@ -23,8 +23,38 @@ export class BMPString extends PkiBase<BMPString> {
         } else if (value instanceof Uint8Array) {
             this.bytes = value
         } else {
-            this.bytes = new TextEncoder().encode(value)
+            // Encode as UTF-16BE (UCS-2 big endian)
+            this.bytes = stringToUtf16BE(value)
         }
+    }
+
+    /**
+     * Converts a string to UTF-16BE (UCS-2 big endian) bytes.
+     */
+    static toUtf16BE(str: string): Uint8Array<ArrayBuffer> {
+        return stringToUtf16BE(str)
+    }
+
+    /**
+     * Converts a password to PKCS#12 form: BMPString (UTF-16BE) with a
+     * trailing 16-bit NUL terminator.
+     *
+     * @param password The password (string or bytes)
+     * @returns UTF-16BE encoded password with NUL terminator
+     */
+    static nullTerminated(
+        password: string | Uint8Array<ArrayBuffer>,
+    ): Uint8Array<ArrayBuffer> {
+        const str =
+            typeof password === 'string'
+                ? password
+                : new TextDecoder().decode(password)
+        // Encode as UTF-16BE, then append NUL terminator
+        const utf16be = stringToUtf16BE(str)
+        const result = new Uint8Array(utf16be.length + 2)
+        result.set(utf16be)
+        // Last 2 bytes are already 0 (null terminator)
+        return result
     }
 
     toAsn1(): Asn1BaseBlock {
@@ -43,19 +73,39 @@ export class BMPString extends PkiBase<BMPString> {
             )
         }
 
-        // Get the binary data from the ASN.1 structure
-        const valueHex = new TextEncoder().encode(asn1.valueBlock.value)
+        // Get the decoded string value from the ASN.1 structure
+        const value = asn1.valueBlock.value
 
-        if (!valueHex) {
+        if (!value) {
             throw new Asn1ParseError(
                 'Could not extract value from ASN.1 BMPString',
             )
         }
 
-        return new BMPString({ value: new Uint8Array(valueHex) })
+        // Pass the string directly - constructor will handle UTF-16BE encoding
+        return new BMPString({ value })
     }
 
     toString() {
-        return new TextDecoder().decode(this.bytes)
+        // Decode UTF-16BE to string
+        let result = ''
+        for (let i = 0; i < this.bytes.length; i += 2) {
+            const code = (this.bytes[i] << 8) | this.bytes[i + 1]
+            result += String.fromCharCode(code)
+        }
+        return result
     }
+}
+
+/**
+ * Converts a string to UTF-16BE (UCS-2 big endian) bytes.
+ */
+function stringToUtf16BE(str: string): Uint8Array<ArrayBuffer> {
+    const bytes = new Uint8Array(str.length * 2)
+    for (let i = 0; i < str.length; i++) {
+        const code = str.charCodeAt(i)
+        bytes[i * 2] = (code >> 8) & 0xff
+        bytes[i * 2 + 1] = code & 0xff
+    }
+    return bytes
 }

--- a/packages/pki-lite/src/core/KeyGen.ts
+++ b/packages/pki-lite/src/core/KeyGen.ts
@@ -17,11 +17,15 @@ import { KeyPair, KeyPairGenOptions } from './crypto/types.js'
  * const { privateKey, publicKey } = await KeyGen.generate({
  *     algorithm: 'RSA',
  *     params: {
- *         modulusLength: 2048,
- *         publicExponent: new Uint8Array([0x01, 0x00, 0x01]), // 65537
+ *         keySize: 2048,
  *         hash: 'SHA-256'
  *     }
  * })
+ *
+ * // Or use convenience methods
+ * const rsaPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+ * const ecPair = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+ * ```
  */
 export class KeyGen {
     /**
@@ -34,12 +38,12 @@ export class KeyGen {
      * ```typescript
      * // Generate an ECDSA key pair using P-256 curve
      * const { privateKey, publicKey } = await KeyGen.generate({
-     *     algorithm: 'ECDSA',
+     *     algorithm: 'EC',
      *     params: {
-     *         namedCurve: 'P-256',
-     *         hash: 'SHA-256'
+     *         namedCurve: 'P-256'
      *     }
      * })
+     * ```
      */
     static async generate(options: KeyPairGenOptions): Promise<{
         privateKey: PrivateKeyInfo
@@ -52,5 +56,73 @@ export class KeyGen {
         const publicKey = SubjectPublicKeyInfo.fromDer(keyPair.publicKey)
 
         return { privateKey, publicKey }
+    }
+
+    /**
+     * Generates an RSA key pair with the specified options.
+     *
+     * @param options RSA key generation options (defaults: keySize=2048, hash='SHA-256')
+     * @returns A PrivateKeyInfo containing the generated RSA key pair
+     *
+     * @example
+     * ```typescript
+     * // Generate 2048-bit RSA key pair
+     * const { privateKey, publicKey } = await KeyGen.generateRsaPair()
+     *
+     * // Generate 4096-bit RSA key pair with SHA-512
+     * const { privateKey, publicKey } = await KeyGen.generateRsaPair({
+     *     keySize: 4096,
+     *     hash: 'SHA-512'
+     * })
+     * ```
+     */
+    static async generateRsaPair(options?: {
+        keySize?: number
+        publicExponent?: number
+        hash?: 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'
+    }): Promise<{
+        privateKey: PrivateKeyInfo
+        publicKey: SubjectPublicKeyInfo
+    }> {
+        return KeyGen.generate({
+            algorithm: 'RSA',
+            params: {
+                keySize: 2048,
+                hash: 'SHA-256',
+                ...options,
+            },
+        })
+    }
+
+    /**
+     * Generates an EC (Elliptic Curve) key pair with the specified curve.
+     *
+     * @param options EC key generation options (defaults: namedCurve='P-256')
+     * @returns A PrivateKeyInfo containing the generated EC key pair
+     *
+     * @example
+     * ```typescript
+     * // Generate P-256 EC key pair (default)
+     * const { privateKey, publicKey } = await KeyGen.generateEcPair()
+     *
+     * // Generate P-384 EC key pair
+     * const { privateKey, publicKey } = await KeyGen.generateEcPair({
+     *     namedCurve: 'P-384'
+     * })
+     * ```
+     */
+    static async generateEcPair(options?: {
+        namedCurve?: 'P-256' | 'P-384' | 'P-521'
+    }): Promise<{
+        privateKey: PrivateKeyInfo
+        publicKey: SubjectPublicKeyInfo
+    }> {
+        return KeyGen.generate({
+            algorithm: 'EC',
+            params: {
+                namedCurve: 'P-256',
+                ...options,
+            },
+        })
     }
 }

--- a/packages/pki-lite/src/core/OIDs.ts
+++ b/packages/pki-lite/src/core/OIDs.ts
@@ -360,6 +360,27 @@ export const OIDs = {
 }
 
 /**
+ * Mapping of PKCS#7 content type names to their OIDs.
+ * Used for convenient type-safe content type specification.
+ */
+export const CONTENT_TYPE_TO_OID = {
+    DATA: OIDs.PKCS7.DATA,
+    SIGNED_DATA: OIDs.PKCS7.SIGNED_DATA,
+    ENVELOPED_DATA: OIDs.PKCS7.ENVELOPED_DATA,
+    SIGNED_AND_ENVELOPED_DATA: OIDs.PKCS7.SIGNED_AND_ENVELOPED_DATA,
+    DIGESTED_DATA: OIDs.PKCS7.DIGESTED_DATA,
+    ENCRYPTED_DATA: OIDs.PKCS7.ENCRYPTED_DATA,
+    AUTHENTICATED_DATA: OIDs.PKCS7.AUTHENTICATED_DATA,
+    AUTH_ENVELOPED_DATA: OIDs.PKCS7.AUTH_ENVELOPED_DATA,
+    TST_INFO: OIDs.PKCS7.TST_INFO,
+} as const
+
+/**
+ * Type representing valid PKCS#7 content type names.
+ */
+export type Pkcs7ContentType = keyof typeof CONTENT_TYPE_TO_OID
+
+/**
  * Mapping of OIDs to their friendly names.
  * This can be used for display purposes or debugging.
  */

--- a/packages/pki-lite/src/core/OIDs.ts
+++ b/packages/pki-lite/src/core/OIDs.ts
@@ -274,6 +274,8 @@ export const OIDs = {
         CHALLENGE_PASSWORD: '1.2.840.113549.1.9.7',
         /** Extension Request */
         EXTENSION_REQUEST: '1.2.840.113549.1.9.14',
+        /** Friendly Name */
+        FRIENDLY_NAME: '1.2.840.113549.1.9.20',
         /** Time Stamp Token */
         TIME_STAMP_TOKEN: '1.2.840.113549.1.9.16.2.14',
         /** Signing Certificate */
@@ -467,6 +469,7 @@ export const OIDToFriendlyName: Record<string, string> = {
     [OIDs.PKCS9.SIGNING_TIME]: 'Signing Time',
     [OIDs.PKCS9.CHALLENGE_PASSWORD]: 'Challenge Password',
     [OIDs.PKCS9.EXTENSION_REQUEST]: 'Extension Request',
+    [OIDs.PKCS9.FRIENDLY_NAME]: 'Friendly Name',
     [OIDs.PKCS9.TIME_STAMP_TOKEN]: 'Time Stamp Token',
     [OIDs.PKCS9.ETS_SIGNING_CERTIFICATE]: 'Signing Certificate',
     [OIDs.PKCS9.ETS_SIGNING_CERTIFICATE_V2]: 'Signing Certificate V2',

--- a/packages/pki-lite/src/core/builders/CertificateBuilder.ts
+++ b/packages/pki-lite/src/core/builders/CertificateBuilder.ts
@@ -1,4 +1,7 @@
-import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import {
+    AlgorithmIdentifier,
+    SignatureAlgorithmIdentifier,
+} from '../../algorithms/AlgorithmIdentifier.js'
 import { Certificate } from '../../x509/Certificate.js'
 import { Extension } from '../../x509/Extension.js'
 import { Name } from '../../x509/Name.js'
@@ -8,6 +11,9 @@ import { TBSCertificate } from '../../x509/TBSCertificate.js'
 import { Validity } from '../../x509/Validity.js'
 import { AsyncBuilder } from './types.js'
 import { AsymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
+import { KeyUsageOptions } from '../../x509/extensions/KeyUsage.js'
+import { ExtKeyCommonNames } from '../../x509/extensions/ExtKeyUsage.js'
+import { GeneralName } from '../../x509/GeneralName.js'
 
 /**
  * Builder class for creating X.509 certificates.
@@ -51,7 +57,9 @@ export class CertificateBuilder implements AsyncBuilder<Certificate> {
     private notAfter?: Date
     private serialNumber?: Uint8Array<ArrayBuffer>
     private extensions: Extension[] = []
-    private algorithm?: AsymmetricEncryptionAlgorithmParams
+    private algorithm?:
+        | AsymmetricEncryptionAlgorithmParams
+        | SignatureAlgorithmIdentifier
     private version: number = 2 // Default to v3 (version 2)
 
     /**
@@ -199,12 +207,150 @@ export class CertificateBuilder implements AsyncBuilder<Certificate> {
     }
 
     /**
-     * Sets the signature algorithm.
+     * Adds a Key Usage extension to the certificate.
      *
-     * @param algorithm Algorithm parameters
+     * @param options Key usage flags
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * builder.addKeyUsage({
+     *     digitalSignature: true,
+     *     keyEncipherment: true
+     * })
+     * ```
+     */
+    addKeyUsage(options: KeyUsageOptions): this {
+        this.extensions.push(Extension.keyUsage(options))
+        return this
+    }
+
+    /**
+     * Adds a Basic Constraints extension to the certificate.
+     *
+     * @param cA Whether this is a CA certificate
+     * @param pathLenConstraint Optional path length constraint
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // CA certificate with path length 1
+     * builder.addBasicConstraints(true, 1)
+     *
+     * // End-entity certificate
+     * builder.addBasicConstraints(false)
+     * ```
+     */
+    addBasicConstraints(cA: boolean, pathLenConstraint?: number): this {
+        this.extensions.push(
+            Extension.basicConstraints({ cA, pathLenConstraint }),
+        )
+        return this
+    }
+
+    /**
+     * Adds a Subject Alternative Name extension to the certificate.
+     * Strings are automatically converted to DNS names.
+     *
+     * @param altNames Alternative names for the subject (strings or GeneralName objects)
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // Simple DNS names as strings
+     * builder.addSubjectAltName('example.com', '*.example.com')
+     *
+     * // Or use GeneralName objects for other types
+     * builder.addSubjectAltName(
+     *     new GeneralName.dNSName({ value: 'example.com' }),
+     *     new GeneralName.rfc822Name({ value: 'admin@example.com' })
+     * )
+     *
+     * // Mix strings and GeneralName objects
+     * builder.addSubjectAltName(
+     *     'example.com',
+     *     new GeneralName.rfc822Name({ value: 'admin@example.com' })
+     * )
+     * ```
+     */
+    addSubjectAltName(...altNames: (string | GeneralName)[]): this {
+        const generalNames = altNames.map((name) =>
+            typeof name === 'string'
+                ? new GeneralName.dNSName({ value: name })
+                : name,
+        )
+        this.extensions.push(Extension.subjectAltName(generalNames))
+        return this
+    }
+
+    /**
+     * Adds an Extended Key Usage extension to the certificate.
+     *
+     * @param options Extended key usage purposes
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * builder.addExtendedKeyUsage({
+     *     serverAuth: true,
+     *     clientAuth: true
+     * })
+     * ```
+     */
+    addExtendedKeyUsage(
+        options: {
+            [key in ExtKeyCommonNames]?: boolean
+        } & {
+            [oid: string]: boolean
+        },
+    ): this {
+        this.extensions.push(Extension.extendedKeyUsage(options))
+        return this
+    }
+
+    /**
+     * Adds a Subject Key Identifier extension to the certificate.
+     *
+     * @param keyIdentifier The key identifier bytes
      * @returns This builder for chaining
      */
-    setAlgorithm(algorithm: AsymmetricEncryptionAlgorithmParams): this {
+    addSubjectKeyIdentifier(keyIdentifier: Uint8Array<ArrayBuffer>): this {
+        this.extensions.push(Extension.subjectKeyIdentifier(keyIdentifier))
+        return this
+    }
+
+    /**
+     * Adds an Authority Key Identifier extension to the certificate.
+     *
+     * @param keyIdentifier The authority key identifier bytes
+     * @returns This builder for chaining
+     */
+    addAuthorityKeyIdentifier(keyIdentifier: Uint8Array<ArrayBuffer>): this {
+        this.extensions.push(Extension.authorityKeyIdentifier(keyIdentifier))
+        return this
+    }
+
+    /**
+     * Sets the signature algorithm.
+     *
+     * @param algorithm Algorithm parameters or SignatureAlgorithmIdentifier
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // Using algorithm parameters
+     * builder.setAlgorithm({
+     *     type: 'ECDSA',
+     *     params: { namedCurve: 'P-256', hash: 'SHA-256' }
+     * })
+     *
+     * // Or using a SignatureAlgorithmIdentifier
+     * builder.setAlgorithm(AlgorithmIdentifier.signatureAlgorithm({
+     *     type: 'RSA_PSS',
+     *     params: { hash: 'SHA-512', saltLength: 64 }
+     * }))
+     * ```
+     */
+    setAlgorithm(
+        algorithm:
+            | AsymmetricEncryptionAlgorithmParams
+            | SignatureAlgorithmIdentifier,
+    ): this {
         this.algorithm = algorithm
         return this
     }
@@ -261,12 +407,15 @@ export class CertificateBuilder implements AsyncBuilder<Certificate> {
             this.generateSerialNumber()
         }
 
-        const signatureAlgorithm = AlgorithmIdentifier.signatureAlgorithm(
-            this.algorithm ?? {
-                type: 'RSASSA_PKCS1_v1_5',
-                params: { hash: 'SHA-256' },
-            },
-        )
+        const signatureAlgorithm =
+            this.algorithm instanceof SignatureAlgorithmIdentifier
+                ? this.algorithm
+                : AlgorithmIdentifier.signatureAlgorithm(
+                      this.algorithm ?? {
+                          type: 'RSASSA_PKCS1_v1_5',
+                          params: { hash: 'SHA-256' },
+                      },
+                  )
 
         const issuerName =
             this.issuer instanceof Certificate
@@ -323,12 +472,15 @@ export class CertificateBuilder implements AsyncBuilder<Certificate> {
             this.generateSerialNumber()
         }
 
-        const signatureAlgorithm = AlgorithmIdentifier.signatureAlgorithm(
-            this.algorithm ?? {
-                type: 'RSASSA_PKCS1_v1_5',
-                params: { hash: 'SHA-256' },
-            },
-        )
+        const signatureAlgorithm =
+            this.algorithm instanceof SignatureAlgorithmIdentifier
+                ? this.algorithm
+                : AlgorithmIdentifier.signatureAlgorithm(
+                      this.algorithm ?? {
+                          type: 'RSASSA_PKCS1_v1_5',
+                          params: { hash: 'SHA-256' },
+                      },
+                  )
 
         const issuerName =
             this.issuer instanceof Certificate

--- a/packages/pki-lite/src/core/builders/CertificateListBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/CertificateListBuilder.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { CertificateList } from '../../x509/CertificateList.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { rsaSigningKeys } from '../../../test-fixtures/signing-keys/rsa-2048/index.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { KeyGen } from '../KeyGen.js'
+
+describe('CertificateListBuilder', () => {
+    it('builds an empty CRL and round-trips', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const crl = await CertificateList.builder()
+            .setIssuerFromCertificate(cert)
+            .setPrivateKey(privateKey)
+            .setThisUpdate(new Date())
+            .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000))
+            .build()
+
+        expect(crl).toBeInstanceOf(CertificateList)
+        expect(crl.tbsCertList.issuer.toString()).toEqual(
+            cert.tbsCertificate.subject.toString(),
+        )
+
+        // Round-trip
+        const der = crl.toDer()
+        const decoded = CertificateList.fromDer(der)
+        expect(decoded.toDer()).toEqual(crl.toDer())
+    })
+
+    it('builds a CRL with revoked certificates', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const crl = await CertificateList.builder()
+            .setIssuerFromCertificate(cert)
+            .setPrivateKey(privateKey)
+            .setThisUpdate(new Date())
+            .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000))
+            .addRevokedCertificate({
+                serialNumber: 12345,
+                revocationDate: new Date('2024-01-01T00:00:00Z'),
+            })
+            .addRevokedCertificate({
+                serialNumber: 67890,
+                revocationDate: new Date('2024-01-02T00:00:00Z'),
+            })
+            .build()
+
+        expect(crl).toBeInstanceOf(CertificateList)
+        expect(crl.tbsCertList.revokedCertificates).toBeDefined()
+        expect(crl.tbsCertList.revokedCertificates!.length).toBe(2)
+    })
+
+    it('builds a CRL revoking a specific certificate', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+
+        // Create a certificate to revoke
+        const userKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const userCert = await Certificate.builder()
+            .setSubject('CN=user@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(userKeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        // Build CRL that revokes this certificate
+        const crl = await CertificateList.builder()
+            .setIssuerFromCertificate(caCert)
+            .setPrivateKey(caPrivateKey)
+            .setThisUpdate(new Date())
+            .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000))
+            .revokeCertificate(userCert)
+            .build()
+
+        expect(crl).toBeInstanceOf(CertificateList)
+        expect(crl.tbsCertList.revokedCertificates).toBeDefined()
+        expect(crl.tbsCertList.revokedCertificates!.length).toBe(1)
+
+        const revokedSerial =
+            crl.tbsCertList.revokedCertificates![0].userCertificate.toString()
+        const userSerial = userCert.tbsCertificate.serialNumber.toString()
+        expect(revokedSerial).toBe(userSerial)
+    })
+
+    it('builds a CRL with custom issuer name', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const crl = await CertificateList.builder()
+            .setIssuer('CN=Custom CA, O=Example Org, C=US')
+            .setPrivateKey(privateKey)
+            .setThisUpdate(new Date('2024-01-01T00:00:00Z'))
+            .setNextUpdate(new Date('2024-02-01T00:00:00Z'))
+            .build()
+
+        expect(crl).toBeInstanceOf(CertificateList)
+        const issuerStr = crl.tbsCertList.issuer.toString()
+        expect(issuerStr).toContain('Custom CA')
+    })
+
+    it('builds a CRL with default validity period', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const beforeBuild = Date.now()
+        const crl = await CertificateList.builder()
+            .setIssuerFromCertificate(cert)
+            .setPrivateKey(privateKey)
+            .build()
+        const afterBuild = Date.now()
+
+        expect(crl).toBeInstanceOf(CertificateList)
+        expect(crl.tbsCertList.thisUpdate).toBeDefined()
+        expect(crl.tbsCertList.nextUpdate).toBeDefined()
+
+        // Verify thisUpdate is around now
+        const thisUpdate = crl.tbsCertList.thisUpdate!.getTime()
+        expect(thisUpdate).toBeGreaterThanOrEqual(beforeBuild - 1000)
+        expect(thisUpdate).toBeLessThanOrEqual(afterBuild + 1000)
+
+        // Verify nextUpdate is ~30 days after thisUpdate
+        const nextUpdate = crl.tbsCertList.nextUpdate!.getTime()
+        const thirtyDays = 30 * 24 * 60 * 60 * 1000
+        expect(nextUpdate - thisUpdate).toBeCloseTo(thirtyDays, -5) // Within ~100s
+    })
+})

--- a/packages/pki-lite/src/core/builders/CertificateListBuilder.ts
+++ b/packages/pki-lite/src/core/builders/CertificateListBuilder.ts
@@ -1,0 +1,258 @@
+import {
+    AlgorithmIdentifier,
+    SignatureAlgorithmIdentifier,
+} from '../../algorithms/AlgorithmIdentifier.js'
+import { CertificateList } from '../../x509/CertificateList.js'
+import { TBSCertList } from '../../x509/TBSCertList.js'
+import { RevokedCertificate } from '../../x509/RevokedCertificate.js'
+import { Extension } from '../../x509/Extension.js'
+import { Name } from '../../x509/Name.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { AsyncBuilder } from './types.js'
+import { AsymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
+
+/** Default CRL validity period: 30 days */
+const DEFAULT_VALIDITY_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * Builder class for creating X.509 Certificate Revocation Lists (CRLs).
+ *
+ * Provides a fluent API for constructing CRLs with revoked certificates,
+ * extensions, and signing them with a CA's private key.
+ *
+ * @example
+ * ```typescript
+ * const crl = await CertificateList.builder()
+ *     .setIssuer('CN=My CA, O=My Org')
+ *     .setPrivateKey(caPrivateKey)
+ *     .setThisUpdate(new Date())
+ *     .setNextUpdate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000))
+ *     .addRevokedCertificate({
+ *         serialNumber: 12345,
+ *         revocationDate: new Date(),
+ *     })
+ *     .build()
+ * ```
+ */
+export class CertificateListBuilder implements AsyncBuilder<CertificateList> {
+    private issuer?: Name
+    private privateKey?: PrivateKeyInfo
+    private thisUpdate?: Date
+    private nextUpdate?: Date
+    private revokedCertificates: RevokedCertificate[] = []
+    private extensions: Extension[] = []
+    private algorithm?:
+        | AsymmetricEncryptionAlgorithmParams
+        | SignatureAlgorithmIdentifier
+    private version?: 1
+
+    /**
+     * Sets the CRL issuer (the CA name).
+     *
+     * @param issuer Issuer DN as string or Name object
+     * @returns This builder for chaining
+     */
+    setIssuer(issuer: string | Name): this {
+        this.issuer = typeof issuer === 'string' ? Name.parse(issuer) : issuer
+        return this
+    }
+
+    /**
+     * Sets the issuer from a CA certificate's subject.
+     *
+     * @param caCertificate The CA certificate
+     * @returns This builder for chaining
+     */
+    setIssuerFromCertificate(caCertificate: Certificate): this {
+        this.issuer = caCertificate.tbsCertificate.subject
+        return this
+    }
+
+    /**
+     * Sets the private key for signing the CRL.
+     *
+     * @param privateKey The CA's private key
+     * @returns This builder for chaining
+     */
+    setPrivateKey(privateKey: PrivateKeyInfo): this {
+        this.privateKey = privateKey
+        return this
+    }
+
+    /**
+     * Sets the thisUpdate time (when this CRL was issued).
+     * Defaults to current time if not set.
+     *
+     * @param date The issue date
+     * @returns This builder for chaining
+     */
+    setThisUpdate(date: Date): this {
+        this.thisUpdate = date
+        return this
+    }
+
+    /**
+     * Sets the nextUpdate time (when the next CRL will be issued).
+     * Defaults to 30 days after thisUpdate if not set.
+     *
+     * @param date The next update date
+     * @returns This builder for chaining
+     */
+    setNextUpdate(date: Date): this {
+        this.nextUpdate = date
+        return this
+    }
+
+    /**
+     * Adds a revoked certificate entry.
+     *
+     * @param entry Revoked certificate details, or a RevokedCertificate instance
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * builder.addRevokedCertificate({
+     *     serialNumber: 12345,
+     *     revocationDate: new Date(),
+     * })
+     * ```
+     */
+    addRevokedCertificate(
+        entry:
+            | RevokedCertificate
+            | {
+                  serialNumber: number | string
+                  revocationDate: Date
+                  crlEntryExtensions?: Extension[]
+              },
+    ): this {
+        if (entry instanceof RevokedCertificate) {
+            this.revokedCertificates.push(entry)
+        } else {
+            this.revokedCertificates.push(
+                new RevokedCertificate({
+                    userCertificate: entry.serialNumber,
+                    revocationDate: entry.revocationDate,
+                    crlEntryExtensions: entry.crlEntryExtensions,
+                }),
+            )
+        }
+        // Adding revoked certs triggers v2 CRL
+        this.version = 1
+        return this
+    }
+
+    /**
+     * Revokes a certificate by reference. Uses the certificate's serial number
+     * and the current time as the revocation date if not provided.
+     *
+     * @param certificate The certificate to revoke
+     * @param revocationDate The revocation date (defaults to now)
+     * @returns This builder for chaining
+     */
+    revokeCertificate(certificate: Certificate, revocationDate?: Date): this {
+        return this.addRevokedCertificate({
+            serialNumber: certificate.tbsCertificate.serialNumber.toString(),
+            revocationDate: revocationDate ?? new Date(),
+        })
+    }
+
+    /**
+     * Adds a CRL extension (e.g., CRL number, authority key identifier).
+     *
+     * @param extension The extension to add
+     * @returns This builder for chaining
+     */
+    addExtension(extension: Extension): this {
+        this.extensions.push(extension)
+        // Extensions trigger v2 CRL
+        this.version = 1
+        return this
+    }
+
+    /**
+     * Adds multiple CRL extensions.
+     *
+     * @param extensions The extensions to add
+     * @returns This builder for chaining
+     */
+    addExtensions(...extensions: Extension[]): this {
+        for (const ext of extensions) {
+            this.addExtension(ext)
+        }
+        return this
+    }
+
+    /**
+     * Sets the signature algorithm.
+     *
+     * @param algorithm Algorithm parameters or SignatureAlgorithmIdentifier
+     * @returns This builder for chaining
+     */
+    setAlgorithm(
+        algorithm:
+            | AsymmetricEncryptionAlgorithmParams
+            | SignatureAlgorithmIdentifier,
+    ): this {
+        this.algorithm = algorithm
+        return this
+    }
+
+    private validate(): void {
+        if (!this.issuer) {
+            throw new Error('Issuer is required')
+        }
+        if (!this.privateKey) {
+            throw new Error('Private key is required for signing CRL')
+        }
+    }
+
+    /**
+     * Builds and signs the CRL.
+     *
+     * @returns Promise resolving to the signed CertificateList
+     */
+    async build(): Promise<CertificateList> {
+        this.validate()
+
+        const signatureAlgorithm =
+            this.algorithm instanceof SignatureAlgorithmIdentifier
+                ? this.algorithm
+                : AlgorithmIdentifier.signatureAlgorithm(
+                      this.algorithm ?? {
+                          type: 'RSASSA_PKCS1_v1_5',
+                          params: { hash: 'SHA-256' },
+                      },
+                  )
+
+        const thisUpdate = this.thisUpdate ?? new Date()
+        const nextUpdate =
+            this.nextUpdate ??
+            new Date(thisUpdate.getTime() + DEFAULT_VALIDITY_MS)
+
+        const tbsCertList = new TBSCertList({
+            version: this.version,
+            signature: signatureAlgorithm,
+            issuer: this.issuer!,
+            thisUpdate,
+            nextUpdate,
+            revokedCertificates:
+                this.revokedCertificates.length > 0
+                    ? this.revokedCertificates
+                    : undefined,
+            extensions:
+                this.extensions.length > 0 ? this.extensions : undefined,
+        })
+
+        const signatureValue = await signatureAlgorithm.sign(
+            tbsCertList,
+            this.privateKey!,
+        )
+
+        return new CertificateList({
+            tbsCertList,
+            signatureAlgorithm,
+            signatureValue,
+        })
+    }
+}

--- a/packages/pki-lite/src/core/builders/CertificateRequestBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/CertificateRequestBuilder.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { CertificateRequest } from '../../x509/CertificateRequest.js'
+import { rsaSigningKeys } from '../../../test-fixtures/signing-keys/rsa-2048/index.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { KeyGen } from '../KeyGen.js'
+
+describe('CertificateRequestBuilder', () => {
+    it('builds a basic CSR and round-trips', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const publicKey = cert.tbsCertificate.subjectPublicKeyInfo
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=example.com, O=Example Org, C=US')
+            .setPublicKey(publicKey)
+            .setPrivateKey(privateKey)
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+        const subjectStr = csr.requestInfo.subject.toString()
+        expect(subjectStr).toContain('example.com')
+
+        // Round-trip
+        const der = csr.toDer()
+        const decoded = CertificateRequest.fromDer(der)
+        expect(decoded.toDer()).toEqual(csr.toDer())
+    })
+
+    it('builds a CSR with key usage extension', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const publicKey = cert.tbsCertificate.subjectPublicKeyInfo
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=server.example.com')
+            .setPublicKey(publicKey)
+            .setPrivateKey(privateKey)
+            .addKeyUsage({
+                digitalSignature: true,
+                keyEncipherment: true,
+            })
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+
+        // Verify extension request attribute is present
+        const attributes = csr.requestInfo.attributes
+        expect(attributes).toBeDefined()
+        expect(attributes!.length).toBeGreaterThan(0)
+    })
+
+    it('builds a CSR with subject alternative names', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const publicKey = cert.tbsCertificate.subjectPublicKeyInfo
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=api.example.com')
+            .setPublicKey(publicKey)
+            .setPrivateKey(privateKey)
+            .addSubjectAltName('api.example.com', '*.api.example.com')
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+
+        // Verify attributes exist
+        const attributes = csr.requestInfo.attributes
+        expect(attributes).toBeDefined()
+        expect(attributes!.length).toBeGreaterThan(0)
+    })
+
+    it('builds a CSR with extended key usage', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const publicKey = cert.tbsCertificate.subjectPublicKeyInfo
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=server.example.com')
+            .setPublicKey(publicKey)
+            .setPrivateKey(privateKey)
+            .addExtendedKeyUsage({
+                serverAuth: true,
+                clientAuth: true,
+            })
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+
+        const attributes = csr.requestInfo.attributes
+        expect(attributes).toBeDefined()
+    })
+
+    it('builds a CSR with multiple extensions', async () => {
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const publicKey = cert.tbsCertificate.subjectPublicKeyInfo
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=multi.example.com, O=Example Corp, C=US')
+            .setPublicKey(publicKey)
+            .setPrivateKey(privateKey)
+            .addKeyUsage({
+                digitalSignature: true,
+                keyEncipherment: true,
+            })
+            .addExtendedKeyUsage({
+                serverAuth: true,
+            })
+            .addSubjectAltName('multi.example.com', 'www.multi.example.com')
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+        expect(csr.requestInfo.attributes!.length).toBeGreaterThan(0)
+    })
+
+    it('builds a CSR with custom signature algorithm', async () => {
+        const keyPair = await KeyGen.generateEcPair({ namedCurve: 'P-256' })
+
+        const csr = await CertificateRequest.builder()
+            .setSubject('CN=ec-test.example.com')
+            .setPublicKey(keyPair.publicKey)
+            .setPrivateKey(keyPair.privateKey)
+            .setAlgorithm({
+                type: 'ECDSA',
+                params: { namedCurve: 'P-256', hash: 'SHA-256' },
+            })
+            .build()
+
+        expect(csr).toBeInstanceOf(CertificateRequest)
+        expect(csr.signatureAlgorithm.algorithm.toString()).toContain(
+            '1.2.840.10045.4.3.2',
+        ) // ecdsa-with-SHA256
+    })
+})

--- a/packages/pki-lite/src/core/builders/CertificateRequestBuilder.ts
+++ b/packages/pki-lite/src/core/builders/CertificateRequestBuilder.ts
@@ -1,0 +1,268 @@
+import {
+    AlgorithmIdentifier,
+    SignatureAlgorithmIdentifier,
+} from '../../algorithms/AlgorithmIdentifier.js'
+import { CertificateRequest } from '../../x509/CertificateRequest.js'
+import { CertificateRequestInfo } from '../../x509/CertificateRequestInfo.js'
+import { Extension } from '../../x509/Extension.js'
+import { Name } from '../../x509/Name.js'
+import { SubjectPublicKeyInfo } from '../../keys/SubjectPublicKeyInfo.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { AsyncBuilder } from './types.js'
+import { AsymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
+import { KeyUsageOptions } from '../../x509/extensions/KeyUsage.js'
+import { ExtKeyCommonNames } from '../../x509/extensions/ExtKeyUsage.js'
+import { GeneralName } from '../../x509/GeneralName.js'
+import { Attribute } from '../../x509/Attribute.js'
+import { OIDs } from '../OIDs.js'
+import { asn1js } from '../PkiBase.js'
+
+/**
+ * Builder class for creating PKCS#10 certificate signing requests (CSRs).
+ *
+ * This builder provides a fluent API for constructing CSRs with
+ * various options including subject, extensions, and signature algorithm.
+ *
+ * @example
+ * ```typescript
+ * // Create a simple CSR
+ * const csr = await CertificateRequest.builder()
+ *     .setSubject('CN=example.com, O=My Org, C=US')
+ *     .setPublicKey(publicKey)
+ *     .setPrivateKey(privateKey)
+ *     .addKeyUsage({ digitalSignature: true, keyEncipherment: true })
+ *     .addSubjectAltName('example.com', '*.example.com')
+ *     .build()
+ * ```
+ */
+export class CertificateRequestBuilder
+    implements AsyncBuilder<CertificateRequest>
+{
+    private subject?: Name
+    private publicKey?: SubjectPublicKeyInfo
+    private privateKey?: PrivateKeyInfo
+    private extensions: Extension[] = []
+    private algorithm?:
+        | AsymmetricEncryptionAlgorithmParams
+        | SignatureAlgorithmIdentifier
+    private version: number = 0 // PKCS#10 v1
+
+    /**
+     * Sets the subject distinguished name for the CSR.
+     *
+     * @param subject Subject DN as string or Name object
+     * @returns This builder for chaining
+     */
+    setSubject(subject: string | Name): this {
+        this.subject =
+            typeof subject === 'string' ? Name.parse(subject) : subject
+        return this
+    }
+
+    /**
+     * Sets the subject's public key.
+     *
+     * @param publicKey The subject's public key
+     * @returns This builder for chaining
+     */
+    setPublicKey(publicKey: SubjectPublicKeyInfo): this {
+        this.publicKey = publicKey
+        return this
+    }
+
+    /**
+     * Sets the private key for signing the CSR.
+     *
+     * @param privateKey The private key
+     * @returns This builder for chaining
+     */
+    setPrivateKey(privateKey: PrivateKeyInfo): this {
+        this.privateKey = privateKey
+        return this
+    }
+
+    /**
+     * Adds an extension to the CSR.
+     * Extensions are included in the extensionRequest attribute.
+     *
+     * @param extension The extension to add
+     * @returns This builder for chaining
+     */
+    addExtension(extension: Extension): this {
+        this.extensions.push(extension)
+        return this
+    }
+
+    /**
+     * Adds multiple extensions to the CSR.
+     *
+     * @param extensions Array of extensions to add
+     * @returns This builder for chaining
+     */
+    addExtensions(...extensions: Extension[]): this {
+        this.extensions.push(...extensions)
+        return this
+    }
+
+    /**
+     * Adds a Key Usage extension to the CSR.
+     *
+     * @param options Key usage flags
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * builder.addKeyUsage({
+     *     digitalSignature: true,
+     *     keyEncipherment: true
+     * })
+     * ```
+     */
+    addKeyUsage(options: KeyUsageOptions): this {
+        this.extensions.push(Extension.keyUsage(options))
+        return this
+    }
+
+    /**
+     * Adds a Subject Alternative Name extension to the CSR.
+     * Strings are automatically converted to DNS names.
+     *
+     * @param altNames Alternative names for the subject (strings or GeneralName objects)
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // Simple DNS names as strings
+     * builder.addSubjectAltName('example.com', '*.example.com')
+     *
+     * // Or use GeneralName objects for other types
+     * builder.addSubjectAltName(
+     *     new GeneralName.dNSName({ value: 'example.com' }),
+     *     new GeneralName.rfc822Name({ value: 'admin@example.com' })
+     * )
+     * ```
+     */
+    addSubjectAltName(...altNames: (string | GeneralName)[]): this {
+        const generalNames = altNames.map((name) =>
+            typeof name === 'string'
+                ? new GeneralName.dNSName({ value: name })
+                : name,
+        )
+        this.extensions.push(Extension.subjectAltName(generalNames))
+        return this
+    }
+
+    /**
+     * Adds an Extended Key Usage extension to the CSR.
+     *
+     * @param options Extended key usage purposes
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * builder.addExtendedKeyUsage({
+     *     serverAuth: true,
+     *     clientAuth: true
+     * })
+     * ```
+     */
+    addExtendedKeyUsage(
+        options: {
+            [key in ExtKeyCommonNames]?: boolean
+        } & {
+            [oid: string]: boolean
+        },
+    ): this {
+        this.extensions.push(Extension.extendedKeyUsage(options))
+        return this
+    }
+
+    /**
+     * Sets the signature algorithm.
+     *
+     * @param algorithm Algorithm parameters or SignatureAlgorithmIdentifier
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // Using algorithm parameters
+     * builder.setAlgorithm({
+     *     type: 'ECDSA',
+     *     params: { namedCurve: 'P-256', hash: 'SHA-256' }
+     * })
+     * ```
+     */
+    setAlgorithm(
+        algorithm:
+            | AsymmetricEncryptionAlgorithmParams
+            | SignatureAlgorithmIdentifier,
+    ): this {
+        this.algorithm = algorithm
+        return this
+    }
+
+    /**
+     * Validates that all required fields are set.
+     * @throws Error if required fields are missing
+     */
+    private validate(): void {
+        if (!this.subject) {
+            throw new Error('Subject is required')
+        }
+        if (!this.publicKey) {
+            throw new Error('Public key is required')
+        }
+        if (!this.privateKey) {
+            throw new Error('Private key is required for signing CSR')
+        }
+    }
+
+    /**
+     * Builds and signs the certificate signing request.
+     *
+     * @returns Promise resolving to the signed CSR
+     * @throws Error if required fields are missing
+     */
+    async build(): Promise<CertificateRequest> {
+        this.validate()
+
+        const signatureAlgorithm =
+            this.algorithm instanceof SignatureAlgorithmIdentifier
+                ? this.algorithm
+                : AlgorithmIdentifier.signatureAlgorithm(
+                      this.algorithm ?? {
+                          type: 'RSASSA_PKCS1_v1_5',
+                          params: { hash: 'SHA-256' },
+                      },
+                  )
+
+        // Create attributes with extension request if extensions exist
+        const attributes: Attribute[] = []
+        if (this.extensions.length > 0) {
+            const extensionsAsn1 = new asn1js.Sequence({
+                value: this.extensions.map((ext) => ext.toAsn1()),
+            })
+
+            attributes.push(
+                new Attribute({
+                    type: OIDs.PKCS9.EXTENSION_REQUEST,
+                    values: [new Uint8Array(extensionsAsn1.toBER())],
+                }),
+            )
+        }
+
+        const requestInfo = new CertificateRequestInfo({
+            version: this.version,
+            subject: this.subject!,
+            publicKey: this.publicKey!,
+            attributes: attributes.length > 0 ? attributes : undefined,
+        })
+
+        const signature = await signatureAlgorithm.sign(
+            requestInfo.toDer(),
+            this.privateKey!,
+        )
+
+        return new CertificateRequest({
+            requestInfo,
+            signatureAlgorithm,
+            signature,
+        })
+    }
+}

--- a/packages/pki-lite/src/core/builders/EncryptedDataBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/EncryptedDataBuilder.test.ts
@@ -10,7 +10,7 @@ describe('EncryptedDataBuilder', () => {
 
     it('builds EncryptedData with default PBES2 algorithm', async () => {
         const encryptedData = await EncryptedData.builder()
-            .setContentType(OIDs.PKCS7.DATA)
+            .setContentTypeOid(OIDs.PKCS7.DATA)
             .setData(testData)
             .setPassword(password)
             .build()
@@ -31,7 +31,7 @@ describe('EncryptedDataBuilder', () => {
         const iv = crypto.getRandomValues(new Uint8Array(16))
 
         const encryptedData = await EncryptedData.builder()
-            .setContentType(OIDs.PKCS7.DATA)
+            .setContentTypeOid(OIDs.PKCS7.DATA)
             .setData(testData)
             .setPassword(password)
             .setAlgorithm({
@@ -84,7 +84,7 @@ describe('EncryptedDataBuilder', () => {
         })
 
         const encryptedData = await EncryptedData.builder()
-            .setContentType(OIDs.PKCS7.DATA)
+            .setContentTypeOid(OIDs.PKCS7.DATA)
             .setData(testData)
             .setPassword(password)
             .setAlgorithm(algorithm)
@@ -108,7 +108,7 @@ describe('EncryptedDataBuilder', () => {
         const customIV = crypto.getRandomValues(new Uint8Array(16))
 
         const encryptedData = await EncryptedData.builder()
-            .setContentType(OIDs.PKCS7.DATA)
+            .setContentTypeOid(OIDs.PKCS7.DATA)
             .setData(testData)
             .setPassword(password)
             .setSalt(customSalt)
@@ -134,7 +134,7 @@ describe('EncryptedDataBuilder', () => {
     it('throws when data is missing', async () => {
         await expect(
             EncryptedData.builder()
-                .setContentType(OIDs.PKCS7.DATA)
+                .setContentTypeOid(OIDs.PKCS7.DATA)
                 .setPassword(password)
                 .build(),
         ).rejects.toThrow('Data is required')
@@ -143,7 +143,7 @@ describe('EncryptedDataBuilder', () => {
     it('throws when password is missing', async () => {
         await expect(
             EncryptedData.builder()
-                .setContentType(OIDs.PKCS7.DATA)
+                .setContentTypeOid(OIDs.PKCS7.DATA)
                 .setData(testData)
                 .build(),
         ).rejects.toThrow('Password is required')

--- a/packages/pki-lite/src/core/builders/EncryptedDataBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/EncryptedDataBuilder.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { EncryptedData } from '../../pkcs7/EncryptedData.js'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { OctetString } from '../../asn1/OctetString.js'
+import { OIDs } from '../OIDs.js'
+
+describe('EncryptedDataBuilder', () => {
+    const testData = new TextEncoder().encode('Hello, World!')
+    const password = 'test-password'
+
+    it('builds EncryptedData with default PBES2 algorithm', async () => {
+        const encryptedData = await EncryptedData.builder()
+            .setContentType(OIDs.PKCS7.DATA)
+            .setData(testData)
+            .setPassword(password)
+            .build()
+
+        expect(encryptedData.version).toBe(0)
+        expect(encryptedData.encryptedContentInfo.contentType.value).toBe(
+            OIDs.PKCS7.DATA,
+        )
+        expect(
+            encryptedData.encryptedContentInfo.encryptedContent,
+        ).toBeDefined()
+        expect(
+            encryptedData.encryptedContentInfo.encryptedContent,
+        ).toBeInstanceOf(OctetString)
+    })
+
+    it('builds EncryptedData with custom algorithm params', async () => {
+        const iv = crypto.getRandomValues(new Uint8Array(16))
+
+        const encryptedData = await EncryptedData.builder()
+            .setContentType(OIDs.PKCS7.DATA)
+            .setData(testData)
+            .setPassword(password)
+            .setAlgorithm({
+                type: 'PBES2',
+                params: {
+                    derivationAlgorithm: {
+                        type: 'PBKDF2',
+                        params: {
+                            salt: crypto.getRandomValues(new Uint8Array(16)),
+                            iterationCount: 4096,
+                            hash: 'SHA-512',
+                        },
+                    },
+                    encryptionAlgorithm: {
+                        type: 'AES_256_CBC',
+                        params: { nonce: iv },
+                    },
+                },
+            })
+            .build()
+
+        expect(encryptedData.version).toBe(0)
+        expect(encryptedData.encryptedContentInfo.contentType.value).toBe(
+            OIDs.PKCS7.DATA,
+        )
+        expect(
+            encryptedData.encryptedContentInfo.encryptedContent,
+        ).toBeDefined()
+    })
+
+    it('builds EncryptedData with ContentEncryptionAlgorithmIdentifier', async () => {
+        const algorithm = AlgorithmIdentifier.contentEncryptionAlgorithm({
+            type: 'PBES2',
+            params: {
+                derivationAlgorithm: {
+                    type: 'PBKDF2',
+                    params: {
+                        salt: crypto.getRandomValues(new Uint8Array(16)),
+                        iterationCount: 8192,
+                        hash: 'SHA-256',
+                    },
+                },
+                encryptionAlgorithm: {
+                    type: 'AES_256_CBC',
+                    params: {
+                        nonce: crypto.getRandomValues(new Uint8Array(16)),
+                    },
+                },
+            },
+        })
+
+        const encryptedData = await EncryptedData.builder()
+            .setContentType(OIDs.PKCS7.DATA)
+            .setData(testData)
+            .setPassword(password)
+            .setAlgorithm(algorithm)
+            .build()
+
+        expect(encryptedData.version).toBe(0)
+        expect(encryptedData.encryptedContentInfo.contentType.value).toBe(
+            OIDs.PKCS7.DATA,
+        )
+        expect(
+            encryptedData.encryptedContentInfo.contentEncryptionAlgorithm,
+        ).toBeDefined()
+        expect(
+            encryptedData.encryptedContentInfo.contentEncryptionAlgorithm
+                .algorithm.value,
+        ).toBe(algorithm.algorithm.value)
+    })
+
+    it('respects custom salt and IV when using default algorithm', async () => {
+        const customSalt = crypto.getRandomValues(new Uint8Array(16))
+        const customIV = crypto.getRandomValues(new Uint8Array(16))
+
+        const encryptedData = await EncryptedData.builder()
+            .setContentType(OIDs.PKCS7.DATA)
+            .setData(testData)
+            .setPassword(password)
+            .setSalt(customSalt)
+            .setIV(customIV)
+            .setIterations(4096)
+            .build()
+
+        expect(encryptedData.version).toBe(0)
+        expect(
+            encryptedData.encryptedContentInfo.encryptedContent,
+        ).toBeDefined()
+    })
+
+    it('throws when content type is missing', async () => {
+        await expect(
+            EncryptedData.builder()
+                .setData(testData)
+                .setPassword(password)
+                .build(),
+        ).rejects.toThrow('Content type is required')
+    })
+
+    it('throws when data is missing', async () => {
+        await expect(
+            EncryptedData.builder()
+                .setContentType(OIDs.PKCS7.DATA)
+                .setPassword(password)
+                .build(),
+        ).rejects.toThrow('Data is required')
+    })
+
+    it('throws when password is missing', async () => {
+        await expect(
+            EncryptedData.builder()
+                .setContentType(OIDs.PKCS7.DATA)
+                .setData(testData)
+                .build(),
+        ).rejects.toThrow('Password is required')
+    })
+})

--- a/packages/pki-lite/src/core/builders/EncryptedDataBuilder.ts
+++ b/packages/pki-lite/src/core/builders/EncryptedDataBuilder.ts
@@ -1,0 +1,204 @@
+import { EncryptedData } from '../../pkcs7/EncryptedData.js'
+import { EncryptedContentInfo } from '../../pkcs7/EncryptedContentInfo.js'
+import {
+    AlgorithmIdentifier,
+    ContentEncryptionAlgorithmIdentifier,
+} from '../../algorithms/AlgorithmIdentifier.js'
+import { SymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
+import { AsyncBuilder } from './types.js'
+
+/**
+ * Builder class for creating PKCS#7 EncryptedData structures.
+ *
+ * Provides a fluent API for encrypting data. By default uses PBES2 (PBKDF2 + AES-256-CBC),
+ * but can accept custom algorithms via setAlgorithm().
+ *
+ * @example
+ * ```typescript
+ * // Using default PBES2 algorithm
+ * const encryptedData = await EncryptedData.builder()
+ *     .setContentType(OIDs.PKCS7.DATA)
+ *     .setData(contentBytes)
+ *     .setPassword('secret')
+ *     .setIterations(2048)
+ *     .build()
+ *
+ * // Using custom algorithm
+ * const customEncrypted = await EncryptedData.builder()
+ *     .setContentType(OIDs.PKCS7.DATA)
+ *     .setData(contentBytes)
+ *     .setPassword('secret')
+ *     .setAlgorithm({
+ *         type: 'AES_256_GCM',
+ *         params: { nonce: randomIV }
+ *     })
+ *     .build()
+ * ```
+ */
+export class EncryptedDataBuilder implements AsyncBuilder<EncryptedData> {
+    private contentType?: string
+    private data?: Uint8Array<ArrayBuffer>
+    private password?: string | Uint8Array<ArrayBuffer>
+    private salt?: Uint8Array<ArrayBuffer>
+    private iv?: Uint8Array<ArrayBuffer>
+    private iterations: number = 2048
+    private algorithm?:
+        | SymmetricEncryptionAlgorithmParams
+        | ContentEncryptionAlgorithmIdentifier
+
+    /**
+     * Sets the content type OID for the encrypted data.
+     *
+     * @param contentType The content type OID
+     * @returns This builder for chaining
+     */
+    setContentType(contentType: string): this {
+        this.contentType = contentType
+        return this
+    }
+
+    /**
+     * Sets the data to encrypt.
+     *
+     * @param data The data bytes
+     * @returns This builder for chaining
+     */
+    setData(data: Uint8Array<ArrayBuffer>): this {
+        this.data = data
+        return this
+    }
+
+    /**
+     * Sets the password for encryption.
+     *
+     * @param password The password (string or bytes)
+     * @returns This builder for chaining
+     */
+    setPassword(password: string | Uint8Array<ArrayBuffer>): this {
+        this.password = password
+        return this
+    }
+
+    /**
+     * Sets the salt for PBKDF2. If not set, a random salt will be generated.
+     *
+     * @param salt The salt bytes
+     * @returns This builder for chaining
+     */
+    setSalt(salt: Uint8Array<ArrayBuffer>): this {
+        this.salt = salt
+        return this
+    }
+
+    /**
+     * Sets the IV for AES encryption. If not set, a random IV will be generated.
+     *
+     * @param iv The IV bytes
+     * @returns This builder for chaining
+     */
+    setIV(iv: Uint8Array<ArrayBuffer>): this {
+        this.iv = iv
+        return this
+    }
+
+    /**
+     * Sets the iteration count for PBKDF2. Defaults to 2048.
+     *
+     * @param iterations The iteration count
+     * @returns This builder for chaining
+     */
+    setIterations(iterations: number): this {
+        this.iterations = iterations
+        return this
+    }
+
+    /**
+     * Sets the encryption algorithm. Accepts either algorithm parameters or a pre-built algorithm identifier.
+     * If not set, defaults to PBES2 (PBKDF2 + AES-256-CBC).
+     *
+     * @param algorithm The encryption algorithm parameters or identifier
+     * @returns This builder for chaining
+     */
+    setAlgorithm(
+        algorithm:
+            | SymmetricEncryptionAlgorithmParams
+            | ContentEncryptionAlgorithmIdentifier,
+    ): this {
+        this.algorithm = algorithm
+        return this
+    }
+
+    private validate(): void {
+        if (!this.contentType) {
+            throw new Error('Content type is required')
+        }
+        if (!this.data) {
+            throw new Error('Data is required')
+        }
+        if (!this.password) {
+            throw new Error('Password is required')
+        }
+    }
+
+    /**
+     * Builds the EncryptedData structure.
+     *
+     * @returns Promise resolving to the EncryptedData instance
+     */
+    async build(): Promise<EncryptedData> {
+        this.validate()
+
+        let encryptionAlgorithm: ContentEncryptionAlgorithmIdentifier
+
+        // Use custom algorithm if provided
+        if (this.algorithm) {
+            if (
+                this.algorithm instanceof ContentEncryptionAlgorithmIdentifier
+            ) {
+                encryptionAlgorithm = this.algorithm
+            } else {
+                encryptionAlgorithm =
+                    AlgorithmIdentifier.contentEncryptionAlgorithm(
+                        this.algorithm,
+                    )
+            }
+        } else {
+            // Default to PBES2 (PBKDF2 + AES-256-CBC)
+            const salt = this.salt ?? crypto.getRandomValues(new Uint8Array(16))
+            const iv = this.iv ?? crypto.getRandomValues(new Uint8Array(16))
+
+            encryptionAlgorithm =
+                AlgorithmIdentifier.contentEncryptionAlgorithm({
+                    type: 'PBES2',
+                    params: {
+                        derivationAlgorithm: {
+                            type: 'PBKDF2',
+                            params: {
+                                salt,
+                                iterationCount: this.iterations,
+                                hash: 'SHA-256',
+                            },
+                        },
+                        encryptionAlgorithm: {
+                            type: 'AES_256_CBC',
+                            params: { nonce: iv },
+                        },
+                    },
+                })
+        }
+
+        const ciphertext = await encryptionAlgorithm.encrypt(
+            this.data!,
+            this.password!,
+        )
+
+        return new EncryptedData({
+            version: 0,
+            encryptedContentInfo: new EncryptedContentInfo({
+                contentType: this.contentType!,
+                contentEncryptionAlgorithm: encryptionAlgorithm,
+                encryptedContent: ciphertext,
+            }),
+        })
+    }
+}

--- a/packages/pki-lite/src/core/builders/EncryptedDataBuilder.ts
+++ b/packages/pki-lite/src/core/builders/EncryptedDataBuilder.ts
@@ -6,6 +6,9 @@ import {
 } from '../../algorithms/AlgorithmIdentifier.js'
 import { SymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
 import { AsyncBuilder } from './types.js'
+import { ObjectIdentifier } from '../../asn1/ObjectIdentifier.js'
+import { ObjectIdentifierString } from '../PkiBase.js'
+import { CONTENT_TYPE_TO_OID, Pkcs7ContentType } from '../OIDs.js'
 
 /**
  * Builder class for creating PKCS#7 EncryptedData structures.
@@ -17,7 +20,7 @@ import { AsyncBuilder } from './types.js'
  * ```typescript
  * // Using default PBES2 algorithm
  * const encryptedData = await EncryptedData.builder()
- *     .setContentType(OIDs.PKCS7.DATA)
+ *     .setContentType('DATA')
  *     .setData(contentBytes)
  *     .setPassword('secret')
  *     .setIterations(2048)
@@ -25,7 +28,7 @@ import { AsyncBuilder } from './types.js'
  *
  * // Using custom algorithm
  * const customEncrypted = await EncryptedData.builder()
- *     .setContentType(OIDs.PKCS7.DATA)
+ *     .setContentType('DATA')
  *     .setData(contentBytes)
  *     .setPassword('secret')
  *     .setAlgorithm({
@@ -36,7 +39,7 @@ import { AsyncBuilder } from './types.js'
  * ```
  */
 export class EncryptedDataBuilder implements AsyncBuilder<EncryptedData> {
-    private contentType?: string
+    private contentType?: ObjectIdentifier
     private data?: Uint8Array<ArrayBuffer>
     private password?: string | Uint8Array<ArrayBuffer>
     private salt?: Uint8Array<ArrayBuffer>
@@ -52,8 +55,21 @@ export class EncryptedDataBuilder implements AsyncBuilder<EncryptedData> {
      * @param contentType The content type OID
      * @returns This builder for chaining
      */
-    setContentType(contentType: string): this {
-        this.contentType = contentType
+    setContentTypeOid(type: ObjectIdentifier | ObjectIdentifierString): this {
+        this.contentType = new ObjectIdentifier({ value: type })
+        return this
+    }
+
+    /**
+     * Sets the content type using a friendly name.
+     *
+     * @param type The content type name
+     * @returns This builder for chaining
+     */
+    setContentType(type: Pkcs7ContentType): this {
+        this.contentType = new ObjectIdentifier({
+            value: CONTENT_TYPE_TO_OID[type],
+        })
         return this
     }
 

--- a/packages/pki-lite/src/core/builders/EnvelopedDataBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/EnvelopedDataBuilder.test.ts
@@ -164,6 +164,11 @@ describe('EnvelopedDataBuilder', () => {
             .build()
 
         expect(envelopedData.recipientInfos).toHaveLength(2)
+        expect(
+            await envelopedData.decrypt(
+                PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem),
+            ),
+        ).toEqual(new TextEncoder().encode(data))
     })
 
     test('encrypted content is different from plaintext', async () => {

--- a/packages/pki-lite/src/core/builders/OCSPRequestBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/OCSPRequestBuilder.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest'
+import { OCSPRequest } from '../../ocsp/OCSPRequest.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { rsaSigningKeys } from '../../../test-fixtures/signing-keys/rsa-2048/index.js'
+import { KeyGen } from '../KeyGen.js'
+import { Request } from '../../ocsp/Request.js'
+import { CertID } from '../../ocsp/CertID.js'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+
+describe('OCSPRequestBuilder', () => {
+    it('builds a basic OCSP request for a single certificate', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+
+        // Create a user certificate
+        const userKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+        const userCert = await Certificate.builder()
+            .setSubject('CN=user@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(userKeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        const request = await OCSPRequest.builder()
+            .addCertificate({
+                certificate: userCert,
+                issuerCertificate: caCert,
+            })
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestList).toBeDefined()
+        expect(request.tbsRequest.requestList.length).toBe(1)
+
+        // Round-trip
+        const der = request.toDer()
+        const decoded = OCSPRequest.fromDer(der)
+        expect(decoded.toDer()).toEqual(request.toDer())
+    })
+
+    it('builds an OCSP request for multiple certificates', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+
+        // Create two user certificates
+        const user1KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+        const user1Cert = await Certificate.builder()
+            .setSubject('CN=user1@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(user1KeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        const user2KeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const user2Cert = await Certificate.builder()
+            .setSubject('CN=user2@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(user2KeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        const request = await OCSPRequest.builder()
+            .addCertificate({
+                certificate: user1Cert,
+                issuerCertificate: caCert,
+            })
+            .addCertificate({
+                certificate: user2Cert,
+                issuerCertificate: caCert,
+            })
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestList.length).toBe(2)
+    })
+
+    it('builds an OCSP request with SHA-1 hash algorithm', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+
+        const userKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+        const userCert = await Certificate.builder()
+            .setSubject('CN=user@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(userKeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        const request = await OCSPRequest.builder()
+            .setHashAlgorithm('SHA-1')
+            .addCertificate({
+                certificate: userCert,
+                issuerCertificate: caCert,
+            })
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestList).toBeDefined()
+
+        // Verify the hash algorithm in CertID is SHA-1
+        const certID = request.tbsRequest.requestList[0].reqCert
+        expect(certID.hashAlgorithm.algorithm.toString()).toBe(
+            '1.3.14.3.2.26', // SHA-1
+        )
+    })
+
+    it('builds an OCSP request with requestor name', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+
+        const userKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+        const userCert = await Certificate.builder()
+            .setSubject('CN=user@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(userKeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        const request = await OCSPRequest.builder()
+            .setRequestorName('CN=OCSP Client, O=Example Org')
+            .addCertificate({
+                certificate: userCert,
+                issuerCertificate: caCert,
+            })
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestorName).toBeDefined()
+    })
+
+    it('builds an OCSP request with pre-built Request', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const hashAlgorithm = AlgorithmIdentifier.digestAlgorithm('SHA-256')
+
+        const certID = new CertID({
+            hashAlgorithm,
+            issuerNameHash: await hashAlgorithm.digest(
+                caCert.tbsCertificate.subject.toDer(),
+            ),
+            issuerKeyHash: await hashAlgorithm.digest(
+                caCert.getSubjectPublicKeyInfo().subjectPublicKey,
+            ),
+            serialNumber: 12345,
+        })
+
+        const prebuiltRequest = new Request({ reqCert: certID })
+
+        const request = await OCSPRequest.builder()
+            .addRequest(prebuiltRequest)
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestList.length).toBe(1)
+    })
+
+    it('builds an OCSP request with extensions', async () => {
+        const caCert = Certificate.fromPem(rsaSigningKeys.certPem)
+
+        const userKeyPair = await KeyGen.generateRsaPair({ keySize: 2048 })
+        const caPrivateKey = PrivateKeyInfo.fromPem(
+            rsaSigningKeys.privateKeyPem,
+        )
+        const userCert = await Certificate.builder()
+            .setSubject('CN=user@example.com')
+            .setIssuer(caCert.tbsCertificate.subject)
+            .setPublicKey(userKeyPair.publicKey)
+            .setPrivateKey(caPrivateKey)
+            .setValidityDays(365)
+            .generateSerialNumber()
+            .build()
+
+        // Create a nonce extension for replay protection
+        const nonce = crypto.getRandomValues(new Uint8Array(16))
+        const nonceExt = {
+            extnID: '1.3.6.1.5.5.7.48.1.2', // OCSP Nonce OID
+            extnValue: nonce,
+        }
+
+        const request = await OCSPRequest.builder()
+            .addCertificate({
+                certificate: userCert,
+                issuerCertificate: caCert,
+            })
+            .addExtension(nonceExt as any)
+            .build()
+
+        expect(request).toBeInstanceOf(OCSPRequest)
+        expect(request.tbsRequest.requestExtensions).toBeDefined()
+    })
+})

--- a/packages/pki-lite/src/core/builders/OCSPRequestBuilder.ts
+++ b/packages/pki-lite/src/core/builders/OCSPRequestBuilder.ts
@@ -1,0 +1,173 @@
+import { OCSPRequest } from '../../ocsp/OCSPRequest.js'
+import { TBSRequest } from '../../ocsp/TBSRequest.js'
+import { Request } from '../../ocsp/Request.js'
+import { CertID } from '../../ocsp/CertID.js'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { Name } from '../../x509/Name.js'
+import { Extension } from '../../x509/Extension.js'
+import { HashAlgorithm } from '../crypto/types.js'
+import { AsyncBuilder } from './types.js'
+
+/**
+ * Builder class for creating OCSP (Online Certificate Status Protocol) requests.
+ *
+ * Provides a fluent API for constructing OCSP requests with one or more
+ * certificate status queries.
+ *
+ * @example
+ * ```typescript
+ * // Single certificate check
+ * const request = await OCSPRequest.builder()
+ *     .addCertificate({
+ *         certificate: clientCert,
+ *         issuerCertificate: caCert,
+ *     })
+ *     .build()
+ *
+ * // Multiple certificates with custom hash algorithm
+ * const request = await OCSPRequest.builder()
+ *     .setHashAlgorithm('SHA-1')
+ *     .addCertificate({ certificate: cert1, issuerCertificate: caCert })
+ *     .addCertificate({ certificate: cert2, issuerCertificate: caCert })
+ *     .build()
+ *
+ * const response = await request.request({ url: 'http://ocsp.example.com' })
+ * ```
+ */
+export class OCSPRequestBuilder implements AsyncBuilder<OCSPRequest> {
+    private version: number = 0
+    private requestorName?: Name
+    private hashAlgorithm: HashAlgorithm = 'SHA-256'
+    private pendingCertificates: Array<{
+        certificate: Certificate
+        issuerCertificate: Certificate
+        singleRequestExtensions?: Extension[]
+    }> = []
+    private requests: Request[] = []
+    private requestExtensions: Extension[] = []
+
+    /**
+     * Sets the hash algorithm used to compute issuer name and key hashes
+     * in CertID. Defaults to 'SHA-256'.
+     *
+     * Note: many OCSP responders only support SHA-1.
+     *
+     * @param hash The hash algorithm
+     * @returns This builder for chaining
+     */
+    setHashAlgorithm(hash: HashAlgorithm): this {
+        this.hashAlgorithm = hash
+        return this
+    }
+
+    /**
+     * Adds a certificate to be checked against its issuer.
+     * The issuer name and key hashes will be computed automatically.
+     *
+     * @param options Certificate and its issuer
+     * @returns This builder for chaining
+     */
+    addCertificate(options: {
+        certificate: Certificate
+        issuerCertificate: Certificate
+        singleRequestExtensions?: Extension[]
+    }): this {
+        this.pendingCertificates.push(options)
+        return this
+    }
+
+    /**
+     * Adds a pre-built Request entry.
+     *
+     * @param request The Request to add
+     * @returns This builder for chaining
+     */
+    addRequest(request: Request): this {
+        this.requests.push(request)
+        return this
+    }
+
+    /**
+     * Sets the requestor's distinguished name (optional).
+     *
+     * @param name Requestor name as string or Name object
+     * @returns This builder for chaining
+     */
+    setRequestorName(name: string | Name): this {
+        this.requestorName = typeof name === 'string' ? Name.parse(name) : name
+        return this
+    }
+
+    /**
+     * Adds a request-level extension (e.g., nonce).
+     *
+     * @param extension The extension to add
+     * @returns This builder for chaining
+     */
+    addExtension(extension: Extension): this {
+        this.requestExtensions.push(extension)
+        return this
+    }
+
+    /**
+     * Sets the protocol version. Defaults to 0 (v1).
+     *
+     * @param version The protocol version
+     * @returns This builder for chaining
+     */
+    setVersion(version: number): this {
+        this.version = version
+        return this
+    }
+
+    /**
+     * Builds the OCSP request, computing CertIDs for all pending certificates.
+     *
+     * @returns Promise resolving to the OCSPRequest
+     */
+    async build(): Promise<OCSPRequest> {
+        const hashAlgorithm = AlgorithmIdentifier.digestAlgorithm(
+            this.hashAlgorithm,
+        )
+
+        const builtRequests: Request[] = [...this.requests]
+        for (const entry of this.pendingCertificates) {
+            const { certificate, issuerCertificate, singleRequestExtensions } =
+                entry
+            const certID = new CertID({
+                hashAlgorithm,
+                issuerNameHash: await hashAlgorithm.digest(
+                    issuerCertificate.tbsCertificate.subject.toDer(),
+                ),
+                issuerKeyHash: await hashAlgorithm.digest(
+                    issuerCertificate.getSubjectPublicKeyInfo()
+                        .subjectPublicKey,
+                ),
+                serialNumber: certificate.tbsCertificate.serialNumber,
+            })
+            builtRequests.push(
+                new Request({
+                    reqCert: certID,
+                    singleRequestExtensions,
+                }),
+            )
+        }
+
+        if (builtRequests.length === 0) {
+            throw new Error('At least one certificate or request is required')
+        }
+
+        const tbsRequest = new TBSRequest({
+            version: this.version,
+            requestorName: this.requestorName,
+            requestList: builtRequests,
+            requestExtensions:
+                this.requestExtensions.length > 0
+                    ? this.requestExtensions
+                    : undefined,
+        })
+
+        return new OCSPRequest({ tbsRequest })
+    }
+}

--- a/packages/pki-lite/src/core/builders/OCSPResponseBuilder.ts
+++ b/packages/pki-lite/src/core/builders/OCSPResponseBuilder.ts
@@ -362,10 +362,12 @@ export class OCSPResponseBuilder implements AsyncBuilder<OCSPResponse> {
 
     private validate(): void {
         // For error responses, we don't need responder info or responses
-        if (
-            this.responseStatus !== OCSPResponseStatus.successful &&
-            typeof this.responseStatus !== 'object'
-        ) {
+        const statusValue =
+            this.responseStatus instanceof OCSPResponseStatus
+                ? this.responseStatus.value
+                : this.responseStatus
+
+        if (statusValue !== 0) {
             return
         }
 
@@ -389,10 +391,12 @@ export class OCSPResponseBuilder implements AsyncBuilder<OCSPResponse> {
         this.validate()
 
         // Handle error responses (no response bytes)
-        if (
-            this.responseStatus !== OCSPResponseStatus.successful &&
-            typeof this.responseStatus !== 'object'
-        ) {
+        const statusValue =
+            this.responseStatus instanceof OCSPResponseStatus
+                ? this.responseStatus.value
+                : this.responseStatus
+
+        if (statusValue !== 0) {
             return new OCSPResponse({
                 responseStatus: this.responseStatus,
             })

--- a/packages/pki-lite/src/core/builders/OCSPResponseBuilder.ts
+++ b/packages/pki-lite/src/core/builders/OCSPResponseBuilder.ts
@@ -1,0 +1,444 @@
+import { OCSPResponse } from '../../ocsp/OCSPResponse.js'
+import { BasicOCSPResponse } from '../../ocsp/BasicOCSPResponse.js'
+import { ResponseData } from '../../ocsp/ResponseData.js'
+import { SingleResponse } from '../../ocsp/SingleResponse.js'
+import { ResponderID } from '../../ocsp/ResponderID.js'
+import { ResponseBytes } from '../../ocsp/ResponseBytes.js'
+import { OCSPResponseStatus } from '../../ocsp/OCSPResponseStatus.js'
+import { CertID } from '../../ocsp/CertID.js'
+import { CertStatus } from '../../ocsp/CertStatus.js'
+import { Extension } from '../../x509/Extension.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { Name } from '../../x509/Name.js'
+import { OctetString } from '../../asn1/OctetString.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import {
+    AlgorithmIdentifier,
+    SignatureAlgorithmIdentifier,
+} from '../../algorithms/AlgorithmIdentifier.js'
+import { AsymmetricEncryptionAlgorithmParams } from '../crypto/types.js'
+import { OIDs } from '../OIDs.js'
+import { AsyncBuilder } from './types.js'
+
+/** Default OCSP response validity: 7 days */
+const DEFAULT_VALIDITY_MS = 7 * 24 * 60 * 60 * 1000
+
+interface CertificateResponseData {
+    issuerCertificate?: Certificate
+    certificate?: Certificate
+    certID?: CertID
+    status: 'good' | 'revoked' | 'unknown'
+    thisUpdate?: Date
+    nextUpdate?: Date
+    revocationTime?: Date
+    revocationReason?: number
+    singleExtensions?: Extension[]
+}
+
+/**
+ * Builder class for creating OCSP Responses.
+ *
+ * Provides a fluent API for constructing OCSP responses with multiple certificate
+ * statuses, responder identification, extensions, and signatures.
+ *
+ * @example
+ * ```typescript
+ * const response = await OCSPResponse.builder()
+ *     .setResponderByName('CN=OCSP Responder')
+ *     .setPrivateKey(responderKey)
+ *     .addResponse(issuerCert, cert1, 'good')
+ *     .addResponse(issuerCert, cert2, 'revoked', {
+ *         revocationTime: new Date(),
+ *         revocationReason: 0
+ *     })
+ *     .build()
+ * ```
+ */
+export class OCSPResponseBuilder implements AsyncBuilder<OCSPResponse> {
+    private responderID?: ResponderID
+    private privateKey?: PrivateKeyInfo
+    private producedAt?: Date
+    private responseData: CertificateResponseData[] = []
+    private responseExtensions: Extension[] = []
+    private certificates: Certificate[] = []
+    private responseStatus: OCSPResponseStatus | number =
+        OCSPResponseStatus.successful
+    private algorithm?:
+        | AsymmetricEncryptionAlgorithmParams
+        | SignatureAlgorithmIdentifier
+
+    /**
+     * Sets the responder ID using a name (byName).
+     *
+     * @param name The responder's distinguished name
+     * @returns This builder for chaining
+     */
+    setResponderByName(name: string | Name): this {
+        this.responderID = typeof name === 'string' ? Name.parse(name) : name
+        return this
+    }
+
+    /**
+     * Sets the responder ID from a certificate's subject.
+     *
+     * @param certificate The responder's certificate
+     * @returns This builder for chaining
+     */
+    setResponderFromCertificate(certificate: Certificate): this {
+        this.responderID = certificate.tbsCertificate.subject
+        return this
+    }
+
+    /**
+     * Sets the responder ID using a key hash (byKey).
+     *
+     * @param keyHash SHA-1 hash of the responder's public key
+     * @returns This builder for chaining
+     */
+    setResponderByKeyHash(keyHash: Uint8Array<ArrayBuffer>): this {
+        this.responderID = new OctetString({ bytes: keyHash })
+        return this
+    }
+
+    /**
+     * Sets the private key for signing the response.
+     *
+     * @param privateKey The responder's private key
+     * @returns This builder for chaining
+     */
+    setPrivateKey(privateKey: PrivateKeyInfo): this {
+        this.privateKey = privateKey
+        return this
+    }
+
+    /**
+     * Sets the producedAt time (when this response was generated).
+     * Defaults to current time if not set.
+     *
+     * @param date The production date
+     * @returns This builder for chaining
+     */
+    setProducedAt(date: Date): this {
+        this.producedAt = date
+        return this
+    }
+
+    /**
+     * Adds a single certificate response.
+     *
+     * @param options Certificate response details
+     * @returns This builder for chaining
+     */
+    addCertificateResponse(options: {
+        issuerCertificate?: Certificate
+        certificate?: Certificate
+        certID?: CertID
+        status: 'good' | 'revoked' | 'unknown'
+        thisUpdate?: Date
+        nextUpdate?: Date
+        revocationTime?: Date
+        revocationReason?: number
+        singleExtensions?: Extension[]
+    }): this {
+        if (!options.certificate && !options.certID) {
+            throw new Error('Either certificate or certID must be provided')
+        }
+        if (options.certificate && options.certID) {
+            throw new Error('Cannot provide both certificate and certID')
+        }
+        if (options.certificate && !options.issuerCertificate) {
+            throw new Error(
+                'issuerCertificate is required when using Certificate objects',
+            )
+        }
+
+        this.responseData.push(options)
+        return this
+    }
+
+    /**
+     * Helper method to create a CertID from issuer and subject certificates.
+     *
+     * @param issuerCertificate The issuer certificate
+     * @param subjectCertificate The subject certificate
+     * @returns Promise resolving to the CertID
+     */
+    private async createCertID(
+        issuerCertificate: Certificate,
+        subjectCertificate: Certificate,
+    ): Promise<CertID> {
+        return CertID.forCertificate(issuerCertificate, subjectCertificate)
+    }
+
+    /**
+     * Converts stored response data to SingleResponse objects.
+     * This is called at build time to create CertIDs from certificates.
+     */
+    private async buildSingleResponses(): Promise<SingleResponse[]> {
+        const responses: SingleResponse[] = []
+
+        for (const data of this.responseData) {
+            // Resolve certID
+            let certID: CertID
+            if (data.certID) {
+                certID = data.certID
+            } else if (data.certificate && data.issuerCertificate) {
+                certID = await this.createCertID(
+                    data.issuerCertificate,
+                    data.certificate,
+                )
+            } else {
+                throw new Error(
+                    'Invalid response data: missing certID and certificate',
+                )
+            }
+
+            // Create cert status
+            const certStatus =
+                data.status === 'good'
+                    ? CertStatus.createGood()
+                    : data.status === 'revoked'
+                      ? CertStatus.createRevoked(
+                            data.revocationTime ?? new Date(),
+                            data.revocationReason,
+                        )
+                      : CertStatus.createUnknown()
+
+            const thisUpdate = data.thisUpdate ?? new Date()
+
+            responses.push(
+                new SingleResponse({
+                    certID,
+                    certStatus,
+                    thisUpdate,
+                    nextUpdate:
+                        data.nextUpdate ??
+                        new Date(thisUpdate.getTime() + DEFAULT_VALIDITY_MS),
+                    singleExtensions: data.singleExtensions,
+                }),
+            )
+        }
+
+        return responses
+    }
+
+    /**
+     * Adds a certificate status response.
+     *
+     * @param issuerOrCertID The issuer certificate (when using Certificate) or CertID directly
+     * @param certificateOrStatus The subject certificate (when using Certificate) or status (when using CertID)
+     * @param statusOrOptions The status (when using Certificate) or options (when using CertID)
+     * @param options Optional parameters (only when using Certificate)
+     * @returns This builder for chaining
+     * @example
+     * ```typescript
+     * // With certificates
+     * builder
+     *   .addResponse(issuerCert, cert1, 'good')
+     *   .addResponse(issuerCert, cert2, 'revoked', {
+     *     revocationTime: new Date(),
+     *     revocationReason: 0
+     *   })
+     *
+     * // With CertID
+     * builder.addResponse(certID, 'good')
+     * ```
+     */
+    addResponse(
+        issuerOrCertID: Certificate | CertID,
+        certificateOrStatus: Certificate | 'good' | 'revoked' | 'unknown',
+        statusOrOptions?:
+            | 'good'
+            | 'revoked'
+            | 'unknown'
+            | {
+                  revocationTime?: Date
+                  revocationReason?: number
+                  thisUpdate?: Date
+                  nextUpdate?: Date
+                  singleExtensions?: Extension[]
+              },
+        options?: {
+            revocationTime?: Date
+            revocationReason?: number
+            thisUpdate?: Date
+            nextUpdate?: Date
+            singleExtensions?: Extension[]
+        },
+    ): this {
+        // Pattern 1: addResponse(issuerCert, subjectCert, status, options?)
+        if (
+            issuerOrCertID instanceof Certificate &&
+            certificateOrStatus instanceof Certificate
+        ) {
+            const status = statusOrOptions as
+                | 'good'
+                | 'revoked'
+                | 'unknown'
+                | undefined
+            if (!status) {
+                throw new Error(
+                    'Status is required when using Certificate objects',
+                )
+            }
+            return this.addCertificateResponse({
+                issuerCertificate: issuerOrCertID,
+                certificate: certificateOrStatus,
+                status,
+                ...options,
+            })
+        }
+        // Pattern 2: addResponse(certID, status, options?)
+        else if (issuerOrCertID instanceof CertID) {
+            const status = certificateOrStatus as 'good' | 'revoked' | 'unknown'
+            const opts = statusOrOptions as
+                | {
+                      revocationTime?: Date
+                      revocationReason?: number
+                      thisUpdate?: Date
+                      nextUpdate?: Date
+                      singleExtensions?: Extension[]
+                  }
+                | undefined
+            return this.addCertificateResponse({
+                certID: issuerOrCertID,
+                status,
+                ...opts,
+            })
+        } else {
+            throw new Error(
+                'Invalid arguments: expected (issuerCert, subjectCert, status, options?) or (certID, status, options?)',
+            )
+        }
+    }
+
+    /**
+     * Adds a response extension (applies to the entire response).
+     *
+     * @param extension The extension to add
+     * @returns This builder for chaining
+     */
+    addResponseExtension(extension: Extension): this {
+        this.responseExtensions.push(extension)
+        return this
+    }
+
+    /**
+     * Adds a certificate to include in the response (for chain validation).
+     *
+     * @param certificate The certificate to include
+     * @returns This builder for chaining
+     */
+    addCertificate(certificate: Certificate): this {
+        this.certificates.push(certificate)
+        return this
+    }
+
+    /**
+     * Sets the overall response status.
+     *
+     * @param status The OCSP response status
+     * @returns This builder for chaining
+     */
+    setResponseStatus(status: OCSPResponseStatus | number): this {
+        this.responseStatus = status
+        return this
+    }
+
+    /**
+     * Sets the signature algorithm.
+     *
+     * @param algorithm Algorithm parameters or SignatureAlgorithmIdentifier
+     * @returns This builder for chaining
+     */
+    setAlgorithm(
+        algorithm:
+            | AsymmetricEncryptionAlgorithmParams
+            | SignatureAlgorithmIdentifier,
+    ): this {
+        this.algorithm = algorithm
+        return this
+    }
+
+    private validate(): void {
+        // For error responses, we don't need responder info or responses
+        if (
+            this.responseStatus !== OCSPResponseStatus.successful &&
+            typeof this.responseStatus !== 'object'
+        ) {
+            return
+        }
+
+        if (!this.responderID) {
+            throw new Error('Responder ID is required')
+        }
+        if (!this.privateKey) {
+            throw new Error('Private key is required for signing')
+        }
+        if (this.responseData.length === 0) {
+            throw new Error('At least one certificate response is required')
+        }
+    }
+
+    /**
+     * Builds and signs the OCSP response.
+     *
+     * @returns Promise resolving to the signed OCSPResponse
+     */
+    async build(): Promise<OCSPResponse> {
+        this.validate()
+
+        // Handle error responses (no response bytes)
+        if (
+            this.responseStatus !== OCSPResponseStatus.successful &&
+            typeof this.responseStatus !== 'object'
+        ) {
+            return new OCSPResponse({
+                responseStatus: this.responseStatus,
+            })
+        }
+
+        const signatureAlgorithm =
+            this.algorithm instanceof SignatureAlgorithmIdentifier
+                ? this.algorithm
+                : AlgorithmIdentifier.signatureAlgorithm(
+                      this.algorithm ?? {
+                          type: 'RSASSA_PKCS1_v1_5',
+                          params: { hash: 'SHA-256' },
+                      },
+                  )
+
+        // Build single responses (this is where CertIDs are created from certificates)
+        const singleResponses = await this.buildSingleResponses()
+
+        const tbsResponseData = new ResponseData({
+            responderID: this.responderID!,
+            producedAt: this.producedAt ?? new Date(),
+            responses: singleResponses,
+            responseExtensions:
+                this.responseExtensions.length > 0
+                    ? this.responseExtensions
+                    : undefined,
+        })
+
+        const signature = await signatureAlgorithm.sign(
+            tbsResponseData,
+            this.privateKey!,
+        )
+
+        const basicResponse = new BasicOCSPResponse({
+            tbsResponseData,
+            signatureAlgorithm,
+            signature,
+            certs: this.certificates.length > 0 ? this.certificates : undefined,
+        })
+
+        return new OCSPResponse({
+            responseStatus: this.responseStatus,
+            responseBytes: new ResponseBytes({
+                responseType: OIDs.PKIX.ID_PKIX_OCSP_BASIC,
+                response: basicResponse,
+            }),
+        })
+    }
+}

--- a/packages/pki-lite/src/core/builders/PFXBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/PFXBuilder.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { PFX } from '../../pkcs12/PFX.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { rsaSigningKeys } from '../../../test-fixtures/signing-keys/rsa-2048/index.js'
+
+describe('PFXBuilder', () => {
+    it('builds a PFX containing certificate + private key and round-trips', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const pfx = await PFX.builder()
+            .addCertificate(cert)
+            .addPrivateKey(privateKey)
+            .setPassword('test-password')
+            .setIterations(1024)
+            .build()
+
+        expect(pfx).toBeInstanceOf(PFX)
+        expect(pfx.macData).toBeDefined()
+
+        // Round-trip
+        const der = pfx.toDer()
+        const decoded = PFX.fromDer(der)
+
+        const certs = await decoded.getX509Certificates('test-password')
+        const keys = await decoded.getPrivateKeys('test-password')
+
+        expect(certs).toHaveLength(1)
+        expect(keys).toHaveLength(1)
+        expect(certs[0].toDer()).toEqual(cert.toDer())
+        expect(keys[0].toDer()).toEqual(privateKey.toDer())
+    })
+
+    it('builds a PFX with friendlyName', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const pfx = await PFX.builder()
+            .addCertificate(cert)
+            .addPrivateKey(privateKey)
+            .setPassword('pw')
+            .setFriendlyName('My Identity')
+            .build()
+
+        const der = pfx.toDer()
+        const decoded = PFX.fromDer(der)
+        const items = await decoded.extractItems('pw')
+        expect(items.certificates).toHaveLength(1)
+        expect(items.privateKeys).toHaveLength(1)
+    })
+
+    it('PFX.create delegates to the builder', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        const privateKey = PrivateKeyInfo.fromPem(rsaSigningKeys.privateKeyPem)
+
+        const pfx = await PFX.create({
+            certificates: [cert],
+            privateKeys: [privateKey],
+            password: 'pw',
+        })
+
+        const decoded = PFX.fromDer(pfx.toDer())
+        const items = await decoded.extractItems('pw')
+        expect(items.certificates).toHaveLength(1)
+        expect(items.privateKeys).toHaveLength(1)
+    })
+
+    it('throws when password is missing', async () => {
+        const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+        await expect(
+            PFX.builder().addCertificate(cert).build(),
+        ).rejects.toThrow(/password/i)
+    })
+
+    it('throws when no certs or keys are provided', async () => {
+        await expect(PFX.builder().setPassword('pw').build()).rejects.toThrow(
+            /at least one certificate/i,
+        )
+    })
+})

--- a/packages/pki-lite/src/core/builders/PFXBuilder.ts
+++ b/packages/pki-lite/src/core/builders/PFXBuilder.ts
@@ -165,12 +165,12 @@ export class PFXBuilder implements AsyncBuilder<PFX> {
 
         if (certBags.length > 0) {
             const safeContents = new SafeContents(...certBags)
-            const encryptedData = await EncryptedData.create(
-                OIDs.PKCS7.DATA,
-                safeContents.toDer(),
+            const encryptedData = await EncryptedData.create({
+                contentType: 'DATA',
+                data: safeContents.toDer(),
                 password,
-                { iterations },
-            )
+                iterations,
+            })
             contentInfos.push(encryptedData.asCms())
         }
 

--- a/packages/pki-lite/src/core/builders/PFXBuilder.ts
+++ b/packages/pki-lite/src/core/builders/PFXBuilder.ts
@@ -1,0 +1,206 @@
+import { PFX } from '../../pkcs12/PFX.js'
+import { Certificate } from '../../x509/Certificate.js'
+import { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
+import { EncryptedPrivateKeyInfo } from '../../keys/EncryptedPrivateKeyInfo.js'
+import { AuthenticatedSafe } from '../../pkcs12/AuthenticatedSafe.js'
+import { SafeBag } from '../../pkcs12/SafeBag.js'
+import { SafeContents } from '../../pkcs12/SafeContents.js'
+import { CertBag } from '../../pkcs12/CertBag.js'
+import { MacData } from '../../pkcs12/MacData.js'
+import { DigestInfo } from '../../pkcs12/DigestInfo.js'
+import { ContentInfo } from '../../pkcs7/ContentInfo.js'
+import { EncryptedData } from '../../pkcs7/EncryptedData.js'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { OctetString } from '../../asn1/OctetString.js'
+import { BMPString } from '../../asn1/BMPString.js'
+import { Attribute } from '../../x509/Attribute.js'
+import { OIDs } from '../OIDs.js'
+import { AsyncBuilder } from './types.js'
+
+/**
+ * Builder class for creating PKCS#12 (PFX) files.
+ *
+ * Provides a fluent API for assembling certificates and private keys into
+ * a password-protected PKCS#12 container. Uses PBES2 (PBKDF2 + AES-256-CBC)
+ * for encryption and HMAC-SHA-256 with PKCS#12 password-based key derivation
+ * (RFC 7292 Appendix B) for the MAC.
+ *
+ * @example
+ * ```typescript
+ * const pfx = await PFX.builder()
+ *     .addCertificate(clientCert)
+ *     .addCertificate(caCert)
+ *     .addPrivateKey(privateKey)
+ *     .setPassword('s3cret')
+ *     .setFriendlyName('My Identity')
+ *     .build()
+ *
+ * const pem = pfx.toPem()
+ * ```
+ */
+export class PFXBuilder implements AsyncBuilder<PFX> {
+    private certificates: Certificate[] = []
+    private privateKeys: PrivateKeyInfo[] = []
+    private password?: string | Uint8Array<ArrayBuffer>
+    private friendlyName?: string
+    private iterations: number = 2048
+
+    /**
+     * Adds a certificate to the PFX. Can be called multiple times to add a chain.
+     *
+     * @param certificates One or more certificates
+     * @returns This builder for chaining
+     */
+    addCertificate(...certificates: Certificate[]): this {
+        this.certificates.push(...certificates)
+        return this
+    }
+
+    /**
+     * Adds a private key to the PFX. The key will be password-encrypted.
+     *
+     * @param privateKeys One or more private keys
+     * @returns This builder for chaining
+     */
+    addPrivateKey(...privateKeys: PrivateKeyInfo[]): this {
+        this.privateKeys.push(...privateKeys)
+        return this
+    }
+
+    /**
+     * Sets the password used to encrypt the private keys and compute the MAC.
+     *
+     * @param password The password (string or bytes)
+     * @returns This builder for chaining
+     */
+    setPassword(password: string | Uint8Array<ArrayBuffer>): this {
+        this.password = password
+        return this
+    }
+
+    /**
+     * Sets an optional friendly name attached to the certificate/key bags.
+     *
+     * @param friendlyName The friendly name
+     * @returns This builder for chaining
+     */
+    setFriendlyName(friendlyName: string): this {
+        this.friendlyName = friendlyName
+        return this
+    }
+
+    /**
+     * Sets the number of iterations used by PBKDF2 and the MAC derivation.
+     * Defaults to 2048.
+     *
+     * @param iterations Iteration count
+     * @returns This builder for chaining
+     */
+    setIterations(iterations: number): this {
+        this.iterations = iterations
+        return this
+    }
+
+    private validate(): void {
+        if (this.password === undefined) {
+            throw new Error('Password is required')
+        }
+        if (this.certificates.length === 0 && this.privateKeys.length === 0) {
+            throw new Error(
+                'At least one certificate or private key is required',
+            )
+        }
+    }
+
+    /**
+     * Builds the PFX container.
+     *
+     * @returns Promise resolving to the PFX instance
+     */
+    async build(): Promise<PFX> {
+        this.validate()
+        const password = this.password!
+        const iterations = this.iterations
+
+        // Common bag attributes (friendlyName)
+        const bagAttributes = this.friendlyName
+            ? [Attribute.friendlyName(this.friendlyName)]
+            : undefined
+
+        // ---- Build key SafeContents (one ContentInfo of type Data) ----
+        const keyBags: SafeBag[] = []
+        for (const privateKey of this.privateKeys) {
+            const encryptedKey = await EncryptedPrivateKeyInfo.create(
+                privateKey,
+                password,
+                { iterations },
+            )
+            keyBags.push(
+                new SafeBag({
+                    bagId: OIDs.PKCS12.BAGS.PKCS8_SHROUDED_KEY_BAG,
+                    bagValue: encryptedKey,
+                    bagAttributes,
+                }),
+            )
+        }
+
+        // ---- Build cert SafeContents (one ContentInfo of type EncryptedData) ----
+        const certBags: SafeBag[] = []
+        for (const certificate of this.certificates) {
+            certBags.push(
+                new SafeBag({
+                    bagId: OIDs.PKCS12.BAGS.CERT_BAG,
+                    bagValue: new CertBag({
+                        certId: OIDs.PKCS12.CERT_TYPES.X509_CERT,
+                        certValue: new OctetString({
+                            bytes: certificate.toDer(),
+                        }),
+                    }),
+                    bagAttributes,
+                }),
+            )
+        }
+
+        const contentInfos: ContentInfo[] = []
+
+        if (certBags.length > 0) {
+            const safeContents = new SafeContents(...certBags)
+            const encryptedData = await EncryptedData.create(
+                OIDs.PKCS7.DATA,
+                safeContents.toDer(),
+                password,
+                { iterations },
+            )
+            contentInfos.push(encryptedData.asCms())
+        }
+
+        if (keyBags.length > 0) {
+            const safeContents = new SafeContents(...keyBags)
+            contentInfos.push(
+                new ContentInfo({
+                    contentType: OIDs.PKCS7.DATA,
+                    content: new OctetString({ bytes: safeContents.toDer() }),
+                }),
+            )
+        }
+
+        const authenticatedSafe = new AuthenticatedSafe(...contentInfos)
+        const authSafeDer = authenticatedSafe.toDer()
+
+        // ---- Compute MAC over the AuthenticatedSafe DER ----
+        const macData = await MacData.create(
+            authSafeDer,
+            password,
+            iterations,
+            'SHA-256',
+        )
+
+        return new PFX({
+            authSafe: new ContentInfo({
+                contentType: OIDs.PKCS7.DATA,
+                content: new OctetString({ bytes: authSafeDer }),
+            }),
+            macData,
+        })
+    }
+}

--- a/packages/pki-lite/src/core/builders/TimeStampReqBuilder.test.ts
+++ b/packages/pki-lite/src/core/builders/TimeStampReqBuilder.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { TimeStampReq } from '../../timestamp/TimeStampReq.js'
+import { MessageImprint } from '../../timestamp/MessageImprint.js'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+
+describe('TimeStampReqBuilder', () => {
+    it('builds a basic timestamp request from data', async () => {
+        const data = new TextEncoder().encode('Hello, world!')
+
+        const tsReq = await TimeStampReq.builder()
+            .setData(data)
+            .setHashAlgorithm('SHA-256')
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.messageImprint).toBeDefined()
+        expect(tsReq.messageImprint.hashAlgorithm.algorithm.toString()).toBe(
+            '2.16.840.1.101.3.4.2.1', // SHA-256
+        )
+
+        // Round-trip
+        const der = tsReq.toDer()
+        const decoded = TimeStampReq.fromDer(der)
+        expect(decoded.toDer()).toEqual(tsReq.toDer())
+    })
+
+    it('builds a timestamp request with string data', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test message for timestamping')
+            .setHashAlgorithm('SHA-256')
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.messageImprint).toBeDefined()
+    })
+
+    it('builds a timestamp request with pre-computed message imprint', async () => {
+        const hashAlg = AlgorithmIdentifier.digestAlgorithm('SHA-256')
+        const data = new TextEncoder().encode('Test data')
+        const hash = await hashAlg.digest(data)
+
+        const messageImprint = new MessageImprint({
+            hashAlgorithm: hashAlg,
+            hashedMessage: hash,
+        })
+
+        const tsReq = await TimeStampReq.builder()
+            .setMessageImprint(messageImprint)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.messageImprint.hashedMessage).toEqual(hash)
+    })
+
+    it('builds a timestamp request with nonce', async () => {
+        const nonce = crypto.getRandomValues(new Uint8Array(8))
+
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setNonce(nonce)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.nonce).toBeDefined()
+        expect(tsReq.nonce).toBeInstanceOf(Uint8Array)
+    })
+
+    it('builds a timestamp request with random nonce', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setRandomNonce(16)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.nonce).toBeDefined()
+    })
+
+    it('builds a timestamp request with certReq flag', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setCertReq(true)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.certReq).toBe(true)
+    })
+
+    it('builds a timestamp request without certReq flag', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setCertReq(false)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.certReq).toBe(false)
+    })
+
+    it('builds a timestamp request with policy OID', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setReqPolicy('1.2.3.4.5')
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.reqPolicy).toBeDefined()
+        expect(tsReq.reqPolicy!.toString()).toBe('1.2.3.4.5')
+    })
+
+    it('builds a timestamp request with SHA-512', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Test data')
+            .setHashAlgorithm('SHA-512')
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.messageImprint.hashAlgorithm.algorithm.toString()).toBe(
+            '2.16.840.1.101.3.4.2.3', // SHA-512
+        )
+    })
+
+    it('builds a timestamp request with all options', async () => {
+        const tsReq = await TimeStampReq.builder()
+            .setData('Complete test data')
+            .setHashAlgorithm('SHA-256')
+            .setRandomNonce(8)
+            .setCertReq(true)
+            .setReqPolicy('1.3.6.1.4.1.4146.2.3')
+            .setVersion(1)
+            .build()
+
+        expect(tsReq).toBeInstanceOf(TimeStampReq)
+        expect(tsReq.version).toBe(1)
+        expect(tsReq.messageImprint).toBeDefined()
+        expect(tsReq.nonce).toBeDefined()
+        expect(tsReq.certReq).toBe(true)
+        expect(tsReq.reqPolicy).toBeDefined()
+    })
+
+    it('defaults to SHA-256 when hash algorithm not specified', async () => {
+        const tsReq = await TimeStampReq.builder().setData('Test data').build()
+
+        expect(tsReq.messageImprint.hashAlgorithm.algorithm.toString()).toBe(
+            '2.16.840.1.101.3.4.2.1', // SHA-256
+        )
+    })
+})

--- a/packages/pki-lite/src/core/builders/TimeStampReqBuilder.ts
+++ b/packages/pki-lite/src/core/builders/TimeStampReqBuilder.ts
@@ -1,0 +1,174 @@
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { TimeStampReq } from '../../timestamp/TimeStampReq.js'
+import { MessageImprint } from '../../timestamp/MessageImprint.js'
+import { Extension } from '../../x509/Extension.js'
+import { ObjectIdentifierString } from '../PkiBase.js'
+import { HashAlgorithm } from '../crypto/types.js'
+import { AsyncBuilder } from './types.js'
+
+/**
+ * Builder class for creating RFC 3161 Time-Stamp Requests.
+ *
+ * Provides a fluent API for constructing TimeStampReq objects, including
+ * automatic hashing of input data.
+ *
+ * @example
+ * ```typescript
+ * // Build from raw data (hash computed automatically)
+ * const tsReq = await TimeStampReq.builder()
+ *     .setData(documentBytes)
+ *     .setHashAlgorithm('SHA-256')
+ *     .setCertReq(true)
+ *     .setNonce(crypto.getRandomValues(new Uint8Array(8)))
+ *     .build()
+ *
+ * // Send to TSA
+ * const response = await tsReq.request({ url: 'https://freetsa.org/tsr' })
+ * ```
+ */
+export class TimeStampReqBuilder implements AsyncBuilder<TimeStampReq> {
+    private version: number = 1
+    private messageImprint?: MessageImprint
+    private data?: Uint8Array<ArrayBuffer>
+    private hashAlgorithm: HashAlgorithm = 'SHA-256'
+    private reqPolicy?: ObjectIdentifierString
+    private nonce?: Uint8Array<ArrayBuffer>
+    private certReq: boolean = false
+    private extensions: Extension[] = []
+
+    /**
+     * Sets the data to be timestamped. The hash will be computed automatically
+     * during build() using the configured hash algorithm.
+     *
+     * @param data The data to timestamp (raw bytes or string)
+     * @returns This builder for chaining
+     */
+    setData(data: Uint8Array<ArrayBuffer> | string): this {
+        this.data =
+            typeof data === 'string' ? new TextEncoder().encode(data) : data
+        return this
+    }
+
+    /**
+     * Sets a pre-computed message imprint, bypassing automatic hashing.
+     *
+     * @param messageImprint The message imprint
+     * @returns This builder for chaining
+     */
+    setMessageImprint(messageImprint: MessageImprint): this {
+        this.messageImprint = messageImprint
+        return this
+    }
+
+    /**
+     * Sets the hash algorithm used to compute the message imprint.
+     * Only used when setData() is provided. Defaults to 'SHA-256'.
+     *
+     * @param hash The hash algorithm
+     * @returns This builder for chaining
+     */
+    setHashAlgorithm(hash: HashAlgorithm): this {
+        this.hashAlgorithm = hash
+        return this
+    }
+
+    /**
+     * Sets the requested TSA policy OID.
+     *
+     * @param policy The TSA policy identifier
+     * @returns This builder for chaining
+     */
+    setReqPolicy(policy: ObjectIdentifierString): this {
+        this.reqPolicy = policy
+        return this
+    }
+
+    /**
+     * Sets the nonce for replay protection.
+     *
+     * @param nonce The nonce bytes (typically 8-16 random bytes)
+     * @returns This builder for chaining
+     */
+    setNonce(nonce: Uint8Array<ArrayBuffer>): this {
+        this.nonce = nonce
+        return this
+    }
+
+    /**
+     * Generates and sets a random nonce for replay protection.
+     *
+     * @param byteLength The length of the random nonce (default 8)
+     * @returns This builder for chaining
+     */
+    setRandomNonce(byteLength: number = 8): this {
+        this.nonce = crypto.getRandomValues(new Uint8Array(byteLength))
+        return this
+    }
+
+    /**
+     * Sets whether to request the TSA certificate in the response.
+     *
+     * @param certReq Whether to request the TSA certificate
+     * @returns This builder for chaining
+     */
+    setCertReq(certReq: boolean = true): this {
+        this.certReq = certReq
+        return this
+    }
+
+    /**
+     * Adds a request extension.
+     *
+     * @param extension The extension to add
+     * @returns This builder for chaining
+     */
+    addExtension(extension: Extension): this {
+        this.extensions.push(extension)
+        return this
+    }
+
+    /**
+     * Sets the protocol version. Defaults to 1.
+     *
+     * @param version The protocol version
+     * @returns This builder for chaining
+     */
+    setVersion(version: number): this {
+        this.version = version
+        return this
+    }
+
+    /**
+     * Builds the timestamp request, computing the message imprint hash if
+     * data was provided via setData().
+     *
+     * @returns Promise resolving to the TimeStampReq
+     */
+    async build(): Promise<TimeStampReq> {
+        let messageImprint = this.messageImprint
+        if (!messageImprint) {
+            if (!this.data) {
+                throw new Error(
+                    'Either setData() or setMessageImprint() is required',
+                )
+            }
+            const algorithm = AlgorithmIdentifier.digestAlgorithm(
+                this.hashAlgorithm,
+            )
+            messageImprint = new MessageImprint({
+                hashAlgorithm: algorithm,
+                hashedMessage: await algorithm.digest(this.data),
+            })
+        }
+
+        return new TimeStampReq({
+            version: this.version,
+            messageImprint,
+            reqPolicy: this.reqPolicy,
+            nonce: this.nonce,
+            certReq: this.certReq,
+            extensions:
+                this.extensions.length > 0 ? this.extensions : undefined,
+        })
+    }
+}

--- a/packages/pki-lite/src/core/crypto/WebCryptoProvider.ts
+++ b/packages/pki-lite/src/core/crypto/WebCryptoProvider.ts
@@ -8,6 +8,7 @@ import { PBES2Params } from '../../pkcs5/PBES2Params.js'
 import { PBEParameter } from '../../pkcs5/PBEParameter.js'
 import { RSAESOAEPParams } from '../../algorithms/RSAESOAEPParams.js'
 import { RSASSAPSSParams } from '../../algorithms/RSASSAPSSParams.js'
+import { BMPString } from '../../asn1/BMPString.js'
 import { ObjectIdentifier } from '../../asn1/ObjectIdentifier.js'
 import { OctetString } from '../../asn1/OctetString.js'
 import type { PrivateKeyInfo } from '../../keys/PrivateKeyInfo.js'
@@ -25,6 +26,7 @@ import type {
     PbeAlgorithmParams,
 } from './types.js'
 import { PBKDF2Params } from '../../pkcs5/PBKDF2Params.js'
+import { pkcs12Derive } from './utils.js'
 
 /**
  * Cryptographic provider implementation using the Web Crypto API.
@@ -449,10 +451,103 @@ export class WebCryptoProvider implements CryptoProvider {
         return derivedKey
     }
 
+    /**
+     * Derives key material using PKCS#12 password-based KDF (RFC 7292 Appendix B).
+     * Supports modern hash algorithms for improved security while maintaining OpenSSL compatibility.
+     *
+     * @param password The password (string or bytes, will be converted to BMPString format)
+     * @param salt Salt value for key derivation
+     * @param iterationCount Number of iterations for key strengthening
+     * @param keyLength Desired key length in bytes
+     * @param purpose Key purpose: 'encryption' (id=1), 'iv' (id=2), or 'mac' (id=3)
+     * @param hash Hash algorithm to use (default: SHA-1 for legacy compatibility)
+     * @returns Promise resolving to the derived key bytes
+     *
+     * @example
+     * ```typescript
+     * // Derive a MAC key with SHA-256
+     * const macKey = await provider.derivePkcs12Key(
+     *     password,
+     *     salt,
+     *     100000,
+     *     32,
+     *     'mac',
+     *     'SHA-256'
+     * )
+     * ```
+     */
+    async derivePkcs12Key(
+        password: string | Uint8Array<ArrayBuffer>,
+        salt: Uint8Array<ArrayBuffer>,
+        iterationCount: number,
+        keyLength: number,
+        purpose: 'encryption' | 'iv' | 'mac' = 'encryption',
+        hash: HashAlgorithm = 'SHA-1',
+    ): Promise<Uint8Array<ArrayBuffer>> {
+        // Convert password to BMPString format (UTF-16BE with NUL terminator)
+        const passwordBytes = BMPString.nullTerminated(password)
+
+        // Map purpose to PKCS#12 id parameter
+        const id = purpose === 'encryption' ? 1 : purpose === 'iv' ? 2 : 3
+
+        return pkcs12Derive(
+            passwordBytes,
+            salt,
+            id,
+            iterationCount,
+            keyLength,
+            hash,
+        )
+    }
+
     async deriveKey(
         password: string | Uint8Array<ArrayBuffer> | CryptoKey,
         algorithm: PbeAlgorithmParams,
     ): Promise<Uint8Array<ArrayBuffer>> {
+        // Handle PKCS#12 PBE algorithms using derivePkcs12Key
+        if (algorithm.type !== 'PBES2') {
+            if (password instanceof CryptoKey) {
+                throw new UnsupportedCryptoAlgorithmError(
+                    `PKCS#12 PBE algorithm ${algorithm.type} requires a password, not a CryptoKey`,
+                )
+            }
+
+            const { salt, iterationCount } = algorithm.params
+
+            // Determine key length based on algorithm
+            let keyLength: number
+            switch (algorithm.type) {
+                case 'PKCS12_SHA1_RC4_128':
+                case 'PKCS12_SHA1_3DES_2KEY':
+                case 'PKCS12_SHA1_RC2_128':
+                    keyLength = 16 // 128 bits
+                    break
+                case 'PKCS12_SHA1_RC4_40':
+                case 'PKCS12_SHA1_RC2_40':
+                    keyLength = 5 // 40 bits
+                    break
+                case 'PKCS12_SHA1_3DES_3KEY':
+                    keyLength = 24 // 192 bits
+                    break
+                default:
+                    // This should never happen if all PKCS#12 algorithms are handled
+                    throw new UnsupportedCryptoAlgorithmError(
+                        `Unsupported PKCS#12 PBE algorithm: ${(algorithm as any).type}`,
+                    )
+            }
+
+            // Legacy PKCS#12 algorithms always use SHA-1
+            return this.derivePkcs12Key(
+                password,
+                salt,
+                iterationCount,
+                keyLength,
+                'encryption',
+                'SHA-1',
+            )
+        }
+
+        // Handle PBES2 using Web Crypto API
         const cryptoKey = await this.deriveCryptoKey(password, algorithm)
         const rawKey = await this.crypto.subtle.exportKey('raw', cryptoKey)
         return new Uint8Array(rawKey)

--- a/packages/pki-lite/src/core/crypto/WebCryptoProvider.ts
+++ b/packages/pki-lite/src/core/crypto/WebCryptoProvider.ts
@@ -5,6 +5,7 @@ import {
 import { CCMParameters } from '../../algorithms/CCMParameters.js'
 import { GCMParameters } from '../../algorithms/GCMParameters.js'
 import { PBES2Params } from '../../pkcs5/PBES2Params.js'
+import { PBEParameter } from '../../pkcs5/PBEParameter.js'
 import { RSAESOAEPParams } from '../../algorithms/RSAESOAEPParams.js'
 import { RSASSAPSSParams } from '../../algorithms/RSASSAPSSParams.js'
 import { ObjectIdentifier } from '../../asn1/ObjectIdentifier.js'
@@ -91,6 +92,36 @@ export class WebCryptoProvider implements CryptoProvider {
     }
 
     /**
+     * Computes an HMAC (Hash-based Message Authentication Code) of the input data.
+     *
+     * @param key The secret key for HMAC
+     * @param data The data to authenticate
+     * @param hash The hash algorithm to use
+     * @returns The computed HMAC bytes
+     * @throws UnsupportedCryptoAlgorithmError if the algorithm is not supported
+     */
+    async hmac(
+        key: Uint8Array<ArrayBuffer>,
+        data: Uint8Array<ArrayBuffer>,
+        hash: HashAlgorithm,
+    ): Promise<Uint8Array<ArrayBuffer>> {
+        if (hash === 'MD5') {
+            throw new UnsupportedCryptoAlgorithmError(
+                'MD5 is not supported in WebCrypto',
+            )
+        }
+        const cryptoKey = await this.crypto.subtle.importKey(
+            'raw',
+            key,
+            { name: 'HMAC', hash: { name: hash } },
+            false,
+            ['sign'],
+        )
+        const signature = await this.crypto.subtle.sign('HMAC', cryptoKey, data)
+        return new Uint8Array(signature)
+    }
+
+    /**
      * Converts PKI algorithm parameters to Web Crypto API algorithm specification.
      *
      * @param algorithm The PKI algorithm parameters
@@ -136,9 +167,9 @@ export class WebCryptoProvider implements CryptoProvider {
                     namedCurve: algorithm.params.namedCurve,
                 }
             default:
+                const _exhaustiveCheck: never = algorithm
                 throw new UnsupportedCryptoAlgorithmError(
-                    //@ts-expect-error
-                    `Unsupported algorithm type: ${algorithm.type}`,
+                    `Unsupported algorithm type: ${_exhaustiveCheck}`,
                 )
         }
     }
@@ -254,17 +285,26 @@ export class WebCryptoProvider implements CryptoProvider {
             case 'AES_192_ECB':
             case 'AES_256_ECB':
                 throw new UnsupportedCryptoAlgorithmError(
-                    'ECB mode is not supported in WebCrypto',
+                    'ECB mode is not supported by WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.',
                 )
             case 'PBES2':
                 throw new UnsupportedCryptoAlgorithmError(
-                    'PBES2 should be handled separately',
+                    'PBES2 is not supported for symmetric encryption in WebCrypto. Use an extended crypto provider that supports legacy algorithms.',
+                )
+            case 'PKCS12_SHA1_3DES_2KEY':
+            case 'PKCS12_SHA1_3DES_3KEY':
+            case 'PKCS12_SHA1_RC2_128':
+            case 'PKCS12_SHA1_RC2_40':
+            case 'PKCS12_SHA1_RC4_128':
+            case 'PKCS12_SHA1_RC4_40':
+                throw new UnsupportedCryptoAlgorithmError(
+                    `PKCS#12 PBE algorithm ${algorithm.type} is not supported by WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.`,
                 )
 
             default:
+                const _exhaustiveCheck1: never = algorithm
                 throw new UnsupportedCryptoAlgorithmError(
-                    //@ts-expect-error
-                    `Unsupported symmetric encryption algorithm: ${algorithm.type}`,
+                    `Unsupported symmetric encryption algorithm: ${_exhaustiveCheck1}`,
                 )
         }
     }
@@ -306,13 +346,26 @@ export class WebCryptoProvider implements CryptoProvider {
             case 'AES_192_ECB':
             case 'AES_256_ECB':
                 throw new UnsupportedCryptoAlgorithmError(
-                    'ECB mode is not supported in WebCrypto',
+                    'ECB mode is not supported by WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.',
+                )
+            case 'PBES2':
+                throw new UnsupportedCryptoAlgorithmError(
+                    'PBES2 is not supported for key generation in WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.',
+                )
+            case 'PKCS12_SHA1_RC4_128':
+            case 'PKCS12_SHA1_RC4_40':
+            case 'PKCS12_SHA1_3DES_3KEY':
+            case 'PKCS12_SHA1_3DES_2KEY':
+            case 'PKCS12_SHA1_RC2_128':
+            case 'PKCS12_SHA1_RC2_40':
+                throw new UnsupportedCryptoAlgorithmError(
+                    `PKCS#12 PBE algorithm ${algorithm} is not supported by WebCryptoProvider`,
                 )
 
             default:
+                const _exhaustiveCheck2: never = algorithm
                 throw new UnsupportedCryptoAlgorithmError(
-                    //@ts-expect-error
-                    `Unsupported symmetric encryption algorithm: ${algorithm.type}`,
+                    `Unsupported symmetric encryption algorithm: ${_exhaustiveCheck2}`,
                 )
         }
 
@@ -366,6 +419,13 @@ export class WebCryptoProvider implements CryptoProvider {
     ): Promise<CryptoKey> {
         if (password instanceof CryptoKey) {
             return password
+        }
+
+        // PKCS#12 PBE algorithms are not supported by Web Crypto API
+        if (algorithm.type !== 'PBES2') {
+            throw new UnsupportedCryptoAlgorithmError(
+                `PKCS#12 PBE algorithm ${algorithm.type} is not supported by WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.`,
+            )
         }
 
         const { derivationAlgorithm } = algorithm.params
@@ -893,10 +953,19 @@ export class WebCryptoProvider implements CryptoProvider {
                     ),
                 })
                 break
+            case 'PKCS12_SHA1_3DES_2KEY':
+            case 'PKCS12_SHA1_3DES_3KEY':
+            case 'PKCS12_SHA1_RC2_128':
+            case 'PKCS12_SHA1_RC2_40':
+            case 'PKCS12_SHA1_RC4_128':
+            case 'PKCS12_SHA1_RC4_40':
+                throw new UnsupportedCryptoAlgorithmError(
+                    `PKCS#12 PBE algorithm ${encryptionParams.type} is not supported by WebCryptoProvider. Use an extended crypto provider that supports legacy algorithms.`,
+                )
             default:
-                throw new Error(
-                    //@ts-expect-error
-                    `Unsupported symmetric encryption algorithm: ${encryptionParams.type}`,
+                const _exhaustiveCheck: never = encryptionParams
+                throw new UnsupportedCryptoAlgorithmError(
+                    `Unsupported symmetric encryption algorithm: ${_exhaustiveCheck}. Use an extended crypto provider that supports legacy algorithms.`,
                 )
         }
 
@@ -944,7 +1013,9 @@ export class WebCryptoProvider implements CryptoProvider {
     }
 
     toPbeAlgorithmParams(algorithm: AlgorithmIdentifier): PbeAlgorithmParams {
-        switch (algorithm.algorithm.toString()) {
+        const oidString = algorithm.algorithm.toString()
+
+        switch (oidString) {
             case OIDs.PKCS5.PBES2: {
                 const parameters = algorithm.parameters?.parseAs(PBES2Params)
                 if (!parameters) {
@@ -965,6 +1036,104 @@ export class WebCryptoProvider implements CryptoProvider {
                     },
                 }
             }
+
+            // PKCS#12 PBE algorithms
+            case OIDs.PKCS12.PBE.SHA1_RC4_128: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_RC4_128',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
+            case OIDs.PKCS12.PBE.SHA1_RC4_40: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_RC4_40',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
+            case OIDs.PKCS12.PBE.SHA1_3DES_3KEY_CBC: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_3DES_3KEY',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
+            case OIDs.PKCS12.PBE.SHA1_3DES_2KEY_CBC: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_3DES_2KEY',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
+            case OIDs.PKCS12.PBE.SHA1_RC2_128_CBC: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_RC2_128',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
+            case OIDs.PKCS12.PBE.SHA1_RC2_40_CBC: {
+                const parameters = algorithm.parameters?.parseAs(PBEParameter)
+                if (!parameters) {
+                    throw new Error(
+                        `Invalid PKCS#12 PBE parameters: ${algorithm.parameters}`,
+                    )
+                }
+                return {
+                    type: 'PKCS12_SHA1_RC2_40',
+                    params: {
+                        salt: parameters.salt.bytes,
+                        iterationCount: parameters.iterationCount,
+                    },
+                }
+            }
+
             default:
                 throw new UnsupportedCryptoAlgorithmError(
                     `Unsupported PBE algorithm: ${algorithm.friendlyName}`,

--- a/packages/pki-lite/src/core/crypto/types.ts
+++ b/packages/pki-lite/src/core/crypto/types.ts
@@ -468,6 +468,27 @@ export interface CryptoProvider {
     ): Promise<Uint8Array<ArrayBuffer>>
 
     /**
+     * Derives key material using PKCS#12 password-based KDF (RFC 7292 Appendix B).
+     * Supports modern hash algorithms for improved security while maintaining OpenSSL compatibility.
+     *
+     * @param password The password (string or bytes, will be converted to BMPString format)
+     * @param salt Salt value for key derivation
+     * @param iterationCount Number of iterations for key strengthening
+     * @param keyLength Desired key length in bytes
+     * @param purpose Key purpose: 'encryption' (id=1), 'iv' (id=2), or 'mac' (id=3)
+     * @param hash Hash algorithm to use (default: SHA-1 for legacy compatibility)
+     * @returns Promise resolving to the derived key bytes
+     */
+    derivePkcs12Key(
+        password: string | Uint8Array<ArrayBuffer>,
+        salt: Uint8Array<ArrayBuffer>,
+        iterationCount: number,
+        keyLength: number,
+        purpose?: 'encryption' | 'iv' | 'mac',
+        hash?: HashAlgorithm,
+    ): Promise<Uint8Array<ArrayBuffer>>
+
+    /**
      * Gets the EC curve parameters for a given asymmetric encryption algorithm.
      *
      * @param algorithm The asymmetric encryption algorithm parameters

--- a/packages/pki-lite/src/core/crypto/types.ts
+++ b/packages/pki-lite/src/core/crypto/types.ts
@@ -118,6 +118,60 @@ export interface PbeAlgorithmParamsMap {
         /** Symmetric encryption algorithm and parameters */
         encryptionAlgorithm: SymmetricEncryptionAlgorithmParams
     }
+    /**
+     * PKCS#12 PBE with SHA-1 and 128-bit RC4.
+     */
+    PKCS12_SHA1_RC4_128: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
+    /**
+     * PKCS#12 PBE with SHA-1 and 40-bit RC4.
+     */
+    PKCS12_SHA1_RC4_40: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
+    /**
+     * PKCS#12 PBE with SHA-1 and 3-key Triple DES-CBC.
+     */
+    PKCS12_SHA1_3DES_3KEY: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
+    /**
+     * PKCS#12 PBE with SHA-1 and 2-key Triple DES-CBC.
+     */
+    PKCS12_SHA1_3DES_2KEY: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
+    /**
+     * PKCS#12 PBE with SHA-1 and 128-bit RC2-CBC.
+     */
+    PKCS12_SHA1_RC2_128: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
+    /**
+     * PKCS#12 PBE with SHA-1 and 40-bit RC2-CBC.
+     */
+    PKCS12_SHA1_RC2_40: {
+        /** Salt value for key derivation */
+        salt: Uint8Array<ArrayBuffer>
+        /** Number of iterations */
+        iterationCount: number
+    }
 }
 
 /**
@@ -271,6 +325,20 @@ export interface CryptoProvider {
      * @returns Promise resolving to the hash digest bytes
      */
     digest(
+        data: Uint8Array<ArrayBuffer>,
+        hash: HashAlgorithm,
+    ): Promise<Uint8Array<ArrayBuffer>>
+
+    /**
+     * Computes an HMAC (Hash-based Message Authentication Code) of the given data.
+     *
+     * @param key The secret key for HMAC
+     * @param data The data to authenticate
+     * @param hash The hash algorithm to use (SHA-1, SHA-256, etc.)
+     * @returns Promise resolving to the HMAC bytes
+     */
+    hmac(
+        key: Uint8Array<ArrayBuffer>,
         data: Uint8Array<ArrayBuffer>,
         hash: HashAlgorithm,
     ): Promise<Uint8Array<ArrayBuffer>>

--- a/packages/pki-lite/src/core/crypto/utils.ts
+++ b/packages/pki-lite/src/core/crypto/utils.ts
@@ -1,0 +1,82 @@
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier'
+import { getCryptoProvider } from './provider'
+import { HashAlgorithm } from './types'
+
+/**
+ * PKCS#12 password-based key derivation (RFC 7292 Appendix B.2).
+ *
+ * @param password Password as BMPString (UTF-16BE) with NUL terminator
+ * @param salt Salt bytes
+ * @param id 1 = encryption key, 2 = IV, 3 = MAC key
+ * @param iterations Iteration count
+ * @param n Number of bytes to produce
+ * @param hash Hash algorithm
+ */
+export async function pkcs12Derive(
+    password: Uint8Array<ArrayBuffer>,
+    salt: Uint8Array<ArrayBuffer>,
+    id: 1 | 2 | 3,
+    iterations: number,
+    n: number,
+    hash: HashAlgorithm,
+): Promise<Uint8Array<ArrayBuffer>> {
+    const digestAlgorithm = AlgorithmIdentifier.digestAlgorithm(hash)
+    const u = digestAlgorithm.getOutputBytes()
+    const v = digestAlgorithm.getBlockBytes()
+    const provider = getCryptoProvider()
+
+    // Step 1: D = ID byte repeated v times
+    const D = new Uint8Array(v).fill(id)
+
+    // Step 2: S = salt extended to ceil(s/v) * v
+    const sLen = salt.length === 0 ? 0 : Math.ceil(salt.length / v) * v
+    const S = new Uint8Array(sLen)
+    for (let i = 0; i < sLen; i++) S[i] = salt[i % salt.length]
+
+    // Step 3: P = password extended to ceil(p/v) * v
+    const pLen = password.length === 0 ? 0 : Math.ceil(password.length / v) * v
+    const P = new Uint8Array(pLen)
+    for (let i = 0; i < pLen; i++) P[i] = password[i % password.length]
+
+    // Step 4: I = S || P
+    let I = new Uint8Array(sLen + pLen)
+    I.set(S)
+    I.set(P, sLen)
+
+    // Step 5: For each block i = 1..c, c = ceil(n/u)
+    const c = Math.ceil(n / u)
+    const result = new Uint8Array(c * u)
+
+    for (let i = 0; i < c; i++) {
+        // a) A_i = H^iterations(D || I)
+        const di = new Uint8Array(D.length + I.length)
+        di.set(D)
+        di.set(I, D.length)
+        let Ai = await provider.digest(di, hash)
+        for (let j = 1; j < iterations; j++) {
+            Ai = await provider.digest(Ai, hash)
+        }
+        result.set(Ai, i * u)
+
+        if (i + 1 === c) break
+
+        // b) B = Ai concatenated to fill v bytes
+        const B = new Uint8Array(v)
+        for (let j = 0; j < v; j++) B[j] = Ai[j % u]
+
+        // c) For each v-byte block I_j of I: I_j = (I_j + B + 1) mod 2^(v*8)
+        const numBlocks = I.length / v
+        const newI = new Uint8Array(I.length)
+        for (let j = 0; j < numBlocks; j++) {
+            let carry = 1n
+            for (let k = v - 1; k >= 0; k--) {
+                const sum = BigInt(I[j * v + k]) + BigInt(B[k]) + carry
+                newI[j * v + k] = Number(sum & 0xffn)
+                carry = sum >> 8n
+            }
+        }
+        I = newI
+    }
+
+    return result.slice(0, n)
+}

--- a/packages/pki-lite/src/core/crypto/utils.ts
+++ b/packages/pki-lite/src/core/crypto/utils.ts
@@ -4,7 +4,6 @@ import { HashAlgorithm } from './types'
 
 /**
  * PKCS#12 password-based key derivation (RFC 7292 Appendix B.2).
- *
  * @param password Password as BMPString (UTF-16BE) with NUL terminator
  * @param salt Salt bytes
  * @param id 1 = encryption key, 2 = IV, 3 = MAC key
@@ -12,6 +11,7 @@ import { HashAlgorithm } from './types'
  * @param n Number of bytes to produce
  * @param hash Hash algorithm
  */
+
 export async function pkcs12Derive(
     password: Uint8Array<ArrayBuffer>,
     salt: Uint8Array<ArrayBuffer>,
@@ -23,7 +23,6 @@ export async function pkcs12Derive(
     const digestAlgorithm = AlgorithmIdentifier.digestAlgorithm(hash)
     const u = digestAlgorithm.getOutputBytes()
     const v = digestAlgorithm.getBlockBytes()
-    const provider = getCryptoProvider()
 
     // Step 1: D = ID byte repeated v times
     const D = new Uint8Array(v).fill(id)
@@ -47,14 +46,16 @@ export async function pkcs12Derive(
     const c = Math.ceil(n / u)
     const result = new Uint8Array(c * u)
 
+    const crypto = getCryptoProvider()
+
     for (let i = 0; i < c; i++) {
         // a) A_i = H^iterations(D || I)
         const di = new Uint8Array(D.length + I.length)
         di.set(D)
         di.set(I, D.length)
-        let Ai = await provider.digest(di, hash)
+        let Ai = await crypto.digest(di, hash)
         for (let j = 1; j < iterations; j++) {
-            Ai = await provider.digest(Ai, hash)
+            Ai = await crypto.digest(Ai, hash)
         }
         result.set(Ai, i * u)
 

--- a/packages/pki-lite/src/core/crypto/utils.ts
+++ b/packages/pki-lite/src/core/crypto/utils.ts
@@ -1,6 +1,6 @@
-import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier'
-import { getCryptoProvider } from './provider'
-import { HashAlgorithm } from './types'
+import { AlgorithmIdentifier } from '../../algorithms/AlgorithmIdentifier.js'
+import { getCryptoProvider } from './provider.js'
+import type { HashAlgorithm } from './types.js'
 
 /**
  * PKCS#12 password-based key derivation (RFC 7292 Appendix B.2).

--- a/packages/pki-lite/src/keys/EncryptedPrivateKeyInfo.ts
+++ b/packages/pki-lite/src/keys/EncryptedPrivateKeyInfo.ts
@@ -1,4 +1,5 @@
 import { ContentEncryptionAlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
+import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
 import { OctetString } from '../asn1/OctetString.js'
 import { asn1js, PkiBase } from '../core/PkiBase.js'
 import { PrivateKeyInfo } from './PrivateKeyInfo.js'
@@ -56,6 +57,56 @@ export class EncryptedPrivateKeyInfo extends PkiBase<EncryptedPrivateKeyInfo> {
 
     static fromDer(der: Uint8Array<ArrayBuffer>): EncryptedPrivateKeyInfo {
         return EncryptedPrivateKeyInfo.fromAsn1(asn1js.fromBER(der).result)
+    }
+
+    /**
+     * Creates an encrypted private key using PBES2 (PBKDF2 + AES-256-CBC).
+     *
+     * @param privateKey The private key to encrypt
+     * @param password The password (string or bytes)
+     * @param options Optional parameters for encryption
+     * @returns Promise resolving to the encrypted private key
+     */
+    static async create(
+        privateKey: PrivateKeyInfo,
+        password: string | Uint8Array<ArrayBuffer>,
+        options?: {
+            salt?: Uint8Array<ArrayBuffer>
+            iv?: Uint8Array<ArrayBuffer>
+            iterations?: number
+        },
+    ): Promise<EncryptedPrivateKeyInfo> {
+        const salt = options?.salt ?? crypto.getRandomValues(new Uint8Array(16))
+        const iv = options?.iv ?? crypto.getRandomValues(new Uint8Array(16))
+        const iterations = options?.iterations ?? 2048
+
+        const algorithm = AlgorithmIdentifier.contentEncryptionAlgorithm({
+            type: 'PBES2',
+            params: {
+                derivationAlgorithm: {
+                    type: 'PBKDF2',
+                    params: {
+                        salt,
+                        iterationCount: iterations,
+                        hash: 'SHA-256',
+                    },
+                },
+                encryptionAlgorithm: {
+                    type: 'AES_256_CBC',
+                    params: { nonce: iv },
+                },
+            },
+        })
+
+        const encryptedData = await algorithm.encrypt(
+            privateKey.toDer(),
+            password,
+        )
+
+        return new EncryptedPrivateKeyInfo({
+            encryptionAlgorithm: algorithm,
+            encryptedData,
+        })
     }
 
     async decrypt(

--- a/packages/pki-lite/src/ocsp/CertID.ts
+++ b/packages/pki-lite/src/ocsp/CertID.ts
@@ -1,16 +1,22 @@
 import { Asn1BaseBlock, asn1js, PkiBase, derToAsn1 } from '../core/PkiBase.js'
-import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
+import {
+    AlgorithmIdentifier,
+    DigestAlgorithmIdentifier,
+} from '../algorithms/AlgorithmIdentifier.js'
 import { OctetString } from '../asn1/OctetString.js'
 import { Integer } from '../asn1/Integer.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { Certificate } from '../x509/Certificate.js'
 
 /**
+ * ```asn
  * CertID ::= SEQUENCE {
  *     hashAlgorithm           AlgorithmIdentifier,
  *     issuerNameHash          OCTET STRING, -- Hash of issuer's DN
  *     issuerKeyHash           OCTET STRING, -- Hash of issuer's key
  *     serialNumber            CertificateSerialNumber
  * }
+ * ```
  */
 export class CertID extends PkiBase<CertID> {
     hashAlgorithm: AlgorithmIdentifier
@@ -83,5 +89,33 @@ export class CertID extends PkiBase<CertID> {
 
     static fromDer(der: Uint8Array<ArrayBuffer>): CertID {
         return CertID.fromAsn1(derToAsn1(der))
+    }
+
+    /**
+     * Creates a CertID from issuer and subject certificates.
+     *
+     * @param issuerCertificate The issuer certificate
+     * @param subjectCertificate The subject certificate
+     * @param hashAlgorithm Optional hash algorithm (defaults to SHA-256)
+     * @returns Promise resolving to the CertID
+     */
+    static async forCertificate(
+        issuerCertificate: Certificate,
+        subjectCertificate: Certificate,
+        hashAlgorithm?: DigestAlgorithmIdentifier,
+    ): Promise<CertID> {
+        const hash =
+            hashAlgorithm ?? AlgorithmIdentifier.digestAlgorithm('SHA-256')
+
+        return new CertID({
+            hashAlgorithm: hash,
+            issuerNameHash: await hash.digest(
+                issuerCertificate.tbsCertificate.subject.toDer(),
+            ),
+            issuerKeyHash: await hash.digest(
+                issuerCertificate.tbsCertificate.subjectPublicKeyInfo.subjectPublicKey.toDer(),
+            ),
+            serialNumber: subjectCertificate.tbsCertificate.serialNumber,
+        })
     }
 }

--- a/packages/pki-lite/src/ocsp/CertStatus.ts
+++ b/packages/pki-lite/src/ocsp/CertStatus.ts
@@ -124,10 +124,8 @@ export class CertStatus extends PkiBase<CertStatus> {
             const revokedInfo = asn1.valueBlock.value[0] as asn1js.Sequence
             const revocationTimeBlock = revokedInfo.valueBlock
                 .value[0] as asn1js.GeneralizedTime
-            // Parse the date from the string value
-            const revocationTime = new Date(
-                revocationTimeBlock.valueBlock.value,
-            )
+            // Parse the date from the GeneralizedTime
+            const revocationTime = revocationTimeBlock.toDate()
 
             let revocationReason: number | undefined = undefined
             if (revokedInfo.valueBlock.value.length > 1) {

--- a/packages/pki-lite/src/ocsp/OCSPRequest.ts
+++ b/packages/pki-lite/src/ocsp/OCSPRequest.ts
@@ -4,6 +4,7 @@ import { OCSPSignature } from './OCSPSignature.js'
 import { OCSPResponse } from './OCSPResponse.js'
 import { Certificate } from '../x509/Certificate.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { OCSPRequestBuilder } from '../core/builders/OCSPRequestBuilder.js'
 
 /**
  * Represents an OCSP (Online Certificate Status Protocol) request.
@@ -74,6 +75,22 @@ export class OCSPRequest extends PkiBase<OCSPRequest> {
      * @param options.issuerCertificate The issuer's certificate
      * @returns A new OCSPRequest instance
      */
+    /**
+     * Creates a fluent builder for constructing OCSP requests.
+     *
+     * @returns A new OCSPRequestBuilder instance
+     *
+     * @example
+     * ```typescript
+     * const request = await OCSPRequest.builder()
+     *     .addCertificate({ certificate: clientCert, issuerCertificate: caCert })
+     *     .build()
+     * ```
+     */
+    static builder(): OCSPRequestBuilder {
+        return new OCSPRequestBuilder()
+    }
+
     static async forCertificate(options: {
         certificate: Certificate
         issuerCertificate: Certificate

--- a/packages/pki-lite/src/ocsp/OCSPResponse.ts
+++ b/packages/pki-lite/src/ocsp/OCSPResponse.ts
@@ -4,15 +4,12 @@ import { ResponseBytes } from './ResponseBytes.js'
 import { BasicOCSPResponse } from './BasicOCSPResponse.js'
 import { OCSPResponseStatus } from './OCSPResponseStatus.js'
 import { Certificate } from '../x509/Certificate.js'
-import { ResponseData } from './ResponseData.js'
 import { Name } from '../x509/Name.js'
 import { AsymmetricEncryptionAlgorithmParams } from '../core/crypto/types.js'
 import { PrivateKeyInfo } from '../keys/PrivateKeyInfo.js'
-import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
-import { SingleResponse } from './SingleResponse.js'
 import { CertID } from './CertID.js'
-import { CertStatus } from './CertStatus.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { OCSPResponseBuilder } from '../core/builders/OCSPResponseBuilder.js'
 
 /**
  * Represents an OCSP (Online Certificate Status Protocol) Response.
@@ -131,6 +128,15 @@ export class OCSPResponse extends PkiBase<OCSPResponse> {
         return this.responseBytes.response.parseAs(BasicOCSPResponse)
     }
 
+    /**
+     * Returns a builder for creating OCSP responses.
+     *
+     * @returns A new OCSPResponseBuilder instance
+     */
+    static builder(): OCSPResponseBuilder {
+        return new OCSPResponseBuilder()
+    }
+
     static async forCertificate(options: {
         issuerCertificate: Certificate
         subjectCertificate: Certificate
@@ -141,68 +147,32 @@ export class OCSPResponse extends PkiBase<OCSPResponse> {
         thisUpdate?: Date
         nextUpdate?: Date
     }): Promise<OCSPResponse> {
-        const signatureAlgorithmParams: AsymmetricEncryptionAlgorithmParams =
-            options.signatureAlgorithmParams ?? {
-                type: 'RSASSA_PKCS1_v1_5',
-                params: {
-                    hash: 'SHA-256',
-                },
-            }
-
-        const signatureAlgorithm = AlgorithmIdentifier.signatureAlgorithm(
-            signatureAlgorithmParams,
+        const certId = await CertID.forCertificate(
+            options.issuerCertificate,
+            options.subjectCertificate,
         )
 
-        const hashAlgorithm = AlgorithmIdentifier.digestAlgorithm('SHA-256')
+        const builder = OCSPResponse.builder()
+            .setPrivateKey(options.privateKey)
+            .addResponse(certId, 'good', {
+                thisUpdate: options.thisUpdate,
+                nextUpdate: options.nextUpdate,
+            })
 
-        const certId = new CertID({
-            hashAlgorithm,
-            issuerNameHash: await hashAlgorithm.digest(
-                options.issuerCertificate.tbsCertificate.issuer.toDer(),
-            ),
-            issuerKeyHash: await hashAlgorithm.digest(
-                options.issuerCertificate.tbsCertificate.subjectPublicKeyInfo.subjectPublicKey.toDer(),
-            ),
-            serialNumber:
-                options.subjectCertificate.tbsCertificate.serialNumber,
-        })
+        if (options.responderID) {
+            builder.setResponderByName(options.responderID)
+        } else {
+            builder.setResponderFromCertificate(options.issuerCertificate)
+        }
 
-        const thisUpdate = options?.thisUpdate ?? new Date()
+        if (options.productedAt) {
+            builder.setProducedAt(options.productedAt)
+        }
 
-        const tbsResponseData = new ResponseData({
-            responderID:
-                options.responderID ??
-                options.issuerCertificate.tbsCertificate.subject,
-            producedAt: options?.productedAt ?? new Date(),
-            responses: [
-                new SingleResponse({
-                    certID: certId,
-                    certStatus: CertStatus.good,
-                    thisUpdate,
-                    nextUpdate:
-                        options?.nextUpdate ??
-                        new Date(
-                            thisUpdate.getTime() + 7 * 24 * 60 * 60 * 1000, // +7 days
-                        ),
-                }),
-            ],
-        })
+        if (options.signatureAlgorithmParams) {
+            builder.setAlgorithm(options.signatureAlgorithmParams)
+        }
 
-        const basicResponse = new BasicOCSPResponse({
-            tbsResponseData,
-            signatureAlgorithm,
-            signature: await signatureAlgorithm.sign(
-                tbsResponseData,
-                options.privateKey,
-            ),
-        })
-
-        return new OCSPResponse({
-            responseStatus: OCSPResponseStatus.successful,
-            responseBytes: new ResponseBytes({
-                responseType: OIDs.PKIX.ID_PKIX_OCSP_BASIC,
-                response: basicResponse,
-            }),
-        })
+        return builder.build()
     }
 }

--- a/packages/pki-lite/src/ocsp/ResponseData.ts
+++ b/packages/pki-lite/src/ocsp/ResponseData.ts
@@ -126,7 +126,7 @@ export class ResponseData extends PkiBase<ResponseData> {
         const producedAtBlock = sequence.valueBlock.value[
             currentIndex
         ] as asn1js.GeneralizedTime
-        const producedAt = new Date(producedAtBlock.valueBlock.value)
+        const producedAt = producedAtBlock.toDate()
         currentIndex++
 
         if (currentIndex >= sequence.valueBlock.value.length) {

--- a/packages/pki-lite/src/ocsp/SingleResponse.ts
+++ b/packages/pki-lite/src/ocsp/SingleResponse.ts
@@ -98,7 +98,7 @@ export class SingleResponse extends PkiBase<SingleResponse> {
         const certStatus = CertStatus.fromAsn1(sequence.valueBlock.value[1])
         const thisUpdateBlock = sequence.valueBlock
             .value[2] as asn1js.GeneralizedTime
-        const thisUpdate = new Date(thisUpdateBlock.valueBlock.value)
+        const thisUpdate = thisUpdateBlock.toDate()
 
         let nextUpdate: Date | undefined = undefined
         let singleExtensions: Extension[] | undefined = undefined
@@ -116,7 +116,7 @@ export class SingleResponse extends PkiBase<SingleResponse> {
                 // nextUpdate
                 const nextUpdateBlock = block.valueBlock
                     .value[0] as asn1js.GeneralizedTime
-                nextUpdate = new Date(nextUpdateBlock.valueBlock.value)
+                nextUpdate = nextUpdateBlock.toDate()
             } else if (
                 block.idBlock.tagClass === 3 &&
                 block.idBlock.tagNumber === 1 &&

--- a/packages/pki-lite/src/pkcs12/MacData.ts
+++ b/packages/pki-lite/src/pkcs12/MacData.ts
@@ -2,6 +2,10 @@ import { OctetString } from '../asn1/OctetString.js'
 import { Asn1BaseBlock, asn1js, PkiBase, derToAsn1 } from '../core/PkiBase.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
 import { DigestInfo } from './DigestInfo.js'
+import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
+import { BMPString } from '../asn1/BMPString.js'
+import { pkcs12Derive } from '../core/crypto/utils.js'
+import type { HashAlgorithm } from '../core/crypto/types.js'
 
 /**
  * Represents a MacData structure in a PKCS#12 file.
@@ -68,5 +72,52 @@ export class MacData extends PkiBase<MacData> {
 
     static fromDer(der: Uint8Array<ArrayBuffer>): MacData {
         return MacData.fromAsn1(derToAsn1(der))
+    }
+
+    /**
+     * Creates a PKCS#12 MacData: HMAC over `data` keyed by a key
+     * derived using the PKCS#12 password-based KDF (RFC 7292 Appendix B).
+     *
+     * Note: Uses the legacy PKCS#12 KDF for MAC key derivation to maintain
+     * compatibility with OpenSSL and other PKCS#12 implementations.
+     *
+     * @param data The data to compute MAC over
+     * @param password The password (string or bytes)
+     * @param iterations Iteration count for KDF
+     * @param hash Hash algorithm to use (default: SHA-256)
+     * @returns Promise resolving to MacData instance
+     */
+    static async create(
+        data: Uint8Array<ArrayBuffer>,
+        password: string | Uint8Array<ArrayBuffer>,
+        iterations: number,
+        hash: HashAlgorithm = 'SHA-256',
+    ): Promise<MacData> {
+        const macSalt = crypto.getRandomValues(new Uint8Array(8))
+        const passwordBytes = BMPString.nullTerminated(password)
+        const digestAlgorithm = AlgorithmIdentifier.digestAlgorithm(hash)
+        const keyLen = digestAlgorithm.getOutputBytes()
+
+        // Use PKCS#12 KDF (RFC 7292 Appendix B) for MAC key derivation
+        // This is required for OpenSSL compatibility
+        const macKey = await pkcs12Derive(
+            passwordBytes,
+            macSalt,
+            3 /* MAC key */,
+            iterations,
+            keyLen,
+            hash,
+        )
+
+        const macValue = await digestAlgorithm.hmac(macKey, data)
+
+        return new MacData({
+            mac: new DigestInfo({
+                digestAlgorithm,
+                digest: new OctetString({ bytes: macValue }),
+            }),
+            macSalt: new OctetString({ bytes: macSalt }),
+            iterations,
+        })
     }
 }

--- a/packages/pki-lite/src/pkcs12/MacData.ts
+++ b/packages/pki-lite/src/pkcs12/MacData.ts
@@ -3,8 +3,7 @@ import { Asn1BaseBlock, asn1js, PkiBase, derToAsn1 } from '../core/PkiBase.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
 import { DigestInfo } from './DigestInfo.js'
 import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
-import { BMPString } from '../asn1/BMPString.js'
-import { pkcs12Derive } from '../core/crypto/utils.js'
+import { getCryptoProvider } from '../core/crypto/provider.js'
 import type { HashAlgorithm } from '../core/crypto/types.js'
 
 /**
@@ -94,18 +93,18 @@ export class MacData extends PkiBase<MacData> {
         hash: HashAlgorithm = 'SHA-256',
     ): Promise<MacData> {
         const macSalt = crypto.getRandomValues(new Uint8Array(8))
-        const passwordBytes = BMPString.nullTerminated(password)
         const digestAlgorithm = AlgorithmIdentifier.digestAlgorithm(hash)
         const keyLen = digestAlgorithm.getOutputBytes()
 
         // Use PKCS#12 KDF (RFC 7292 Appendix B) for MAC key derivation
         // This is required for OpenSSL compatibility
-        const macKey = await pkcs12Derive(
-            passwordBytes,
+        const provider = getCryptoProvider()
+        const macKey = await provider.derivePkcs12Key(
+            password,
             macSalt,
-            3 /* MAC key */,
             iterations,
             keyLen,
+            'mac',
             hash,
         )
 

--- a/packages/pki-lite/src/pkcs12/PFX.ts
+++ b/packages/pki-lite/src/pkcs12/PFX.ts
@@ -16,6 +16,7 @@ import { EncryptedPrivateKeyInfo } from '../keys/EncryptedPrivateKeyInfo.js'
 import { CertBag } from './CertBag.js'
 import { Certificate } from '../x509/Certificate.js'
 import { OctetString } from '../asn1/OctetString.js'
+import { PFXBuilder } from '../core/builders/PFXBuilder.js'
 
 /**
  * Represents a PFX structure in a PKCS#12 file.
@@ -231,12 +232,47 @@ export class PFX extends PkiBase<PFX> {
      * @param options.friendlyName Optional friendly name for the key/cert pairs
      * @returns A new PFX instance
      */
+    /**
+     * Creates a fluent builder for constructing PFX containers.
+     *
+     * @returns A new PFXBuilder instance
+     *
+     * @example
+     * ```typescript
+     * const pfx = await PFX.builder()
+     *     .addCertificate(cert)
+     *     .addPrivateKey(privateKey)
+     *     .setPassword('secret')
+     *     .build()
+     * ```
+     */
+    static builder(): PFXBuilder {
+        return new PFXBuilder()
+    }
+
+    /**
+     * Creates a new PFX instance containing the given certificates and private keys.
+     *
+     * @param options Configuration object
+     * @param options.certificates Array of certificates to include
+     * @param options.privateKeys Array of private keys to include
+     * @param options.password Password to encrypt the private keys
+     * @param options.friendlyName Optional friendly name for the key/cert pairs
+     * @returns A new PFX instance
+     */
     static async create(options: {
         certificates: Certificate[]
         privateKeys: PrivateKeyInfo[]
         password: string | Uint8Array<ArrayBuffer>
         friendlyName?: string
     }): Promise<PFX> {
-        throw new Error('Not implemented yet')
+        const builder = PFX.builder()
+            .addCertificate(...options.certificates)
+            .addPrivateKey(...options.privateKeys)
+            .setPassword(options.password)
+        if (options.friendlyName) {
+            builder.setFriendlyName(options.friendlyName)
+        }
+        return builder.build()
     }
 }

--- a/packages/pki-lite/src/pkcs7/EncryptedData.ts
+++ b/packages/pki-lite/src/pkcs7/EncryptedData.ts
@@ -2,7 +2,7 @@ import { Asn1BaseBlock, asn1js, PkiBase } from '../core/PkiBase.js'
 import { EncryptedContentInfo } from './EncryptedContentInfo.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
 import { ContentInfo } from './ContentInfo.js'
-import { OIDs } from '../core/OIDs.js'
+import { OIDs, Pkcs7ContentType } from '../core/OIDs.js'
 import { EncryptedDataBuilder } from '../core/builders/EncryptedDataBuilder.js'
 
 /**
@@ -87,30 +87,25 @@ export class EncryptedData extends PkiBase<EncryptedData> {
     /**
      * Creates an encrypted data structure using PBES2 (PBKDF2 + AES-256-CBC).
      *
-     * @param contentType The content type OID
-     * @param data The data to encrypt
-     * @param password The password (string or bytes)
-     * @param options Optional parameters for encryption
+     * @param options Configuration for creating encrypted data
      * @returns Promise resolving to the encrypted data
      */
-    static async create(
-        contentType: string,
-        data: Uint8Array<ArrayBuffer>,
-        password: string | Uint8Array<ArrayBuffer>,
-        options?: {
-            salt?: Uint8Array<ArrayBuffer>
-            iv?: Uint8Array<ArrayBuffer>
-            iterations?: number
-        },
-    ): Promise<EncryptedData> {
+    static async create(options: {
+        contentType: Pkcs7ContentType
+        data: Uint8Array<ArrayBuffer>
+        password: string | Uint8Array<ArrayBuffer>
+        salt?: Uint8Array<ArrayBuffer>
+        iv?: Uint8Array<ArrayBuffer>
+        iterations?: number
+    }): Promise<EncryptedData> {
         const builder = EncryptedData.builder()
-            .setContentType(contentType)
-            .setData(data)
-            .setPassword(password)
+            .setContentType(options.contentType)
+            .setData(options.data)
+            .setPassword(options.password)
 
-        if (options?.salt) builder.setSalt(options.salt)
-        if (options?.iv) builder.setIV(options.iv)
-        if (options?.iterations) builder.setIterations(options.iterations)
+        if (options.salt) builder.setSalt(options.salt)
+        if (options.iv) builder.setIV(options.iv)
+        if (options.iterations) builder.setIterations(options.iterations)
 
         return builder.build()
     }

--- a/packages/pki-lite/src/pkcs7/EncryptedData.ts
+++ b/packages/pki-lite/src/pkcs7/EncryptedData.ts
@@ -1,6 +1,9 @@
 import { Asn1BaseBlock, asn1js, PkiBase } from '../core/PkiBase.js'
 import { EncryptedContentInfo } from './EncryptedContentInfo.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { ContentInfo } from './ContentInfo.js'
+import { OIDs } from '../core/OIDs.js'
+import { EncryptedDataBuilder } from '../core/builders/EncryptedDataBuilder.js'
 
 /**
  * Represents a PKCS#7 EncryptedData structure.
@@ -70,5 +73,52 @@ export class EncryptedData extends PkiBase<EncryptedData> {
         const encryptedContentInfo = EncryptedContentInfo.fromAsn1(values[1])
 
         return new EncryptedData({ version, encryptedContentInfo })
+    }
+
+    /**
+     * Returns a builder for creating encrypted data.
+     *
+     * @returns A new EncryptedDataBuilder instance
+     */
+    static builder(): EncryptedDataBuilder {
+        return new EncryptedDataBuilder()
+    }
+
+    /**
+     * Creates an encrypted data structure using PBES2 (PBKDF2 + AES-256-CBC).
+     *
+     * @param contentType The content type OID
+     * @param data The data to encrypt
+     * @param password The password (string or bytes)
+     * @param options Optional parameters for encryption
+     * @returns Promise resolving to the encrypted data
+     */
+    static async create(
+        contentType: string,
+        data: Uint8Array<ArrayBuffer>,
+        password: string | Uint8Array<ArrayBuffer>,
+        options?: {
+            salt?: Uint8Array<ArrayBuffer>
+            iv?: Uint8Array<ArrayBuffer>
+            iterations?: number
+        },
+    ): Promise<EncryptedData> {
+        const builder = EncryptedData.builder()
+            .setContentType(contentType)
+            .setData(data)
+            .setPassword(password)
+
+        if (options?.salt) builder.setSalt(options.salt)
+        if (options?.iv) builder.setIV(options.iv)
+        if (options?.iterations) builder.setIterations(options.iterations)
+
+        return builder.build()
+    }
+
+    asCms(): ContentInfo {
+        return new ContentInfo({
+            contentType: OIDs.PKCS7.ENCRYPTED_DATA,
+            content: this,
+        })
     }
 }

--- a/packages/pki-lite/src/timestamp/TimeStampReq.ts
+++ b/packages/pki-lite/src/timestamp/TimeStampReq.ts
@@ -10,6 +10,7 @@ import { Extension } from '../x509/Extension.js'
 import { TimeStampResp } from './TimeStampResp.js'
 import { ObjectIdentifier } from '../asn1/ObjectIdentifier.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { TimeStampReqBuilder } from '../core/builders/TimeStampReqBuilder.js'
 
 /**
  * Time-Stamp Request structure for RFC 3161 Time-Stamp Protocol.
@@ -399,6 +400,24 @@ export class TimeStampReq extends PkiBase<TimeStampReq> {
      * })
      * ```
      */
+    /**
+     * Creates a fluent builder for constructing TimeStampReq objects.
+     *
+     * @returns A new TimeStampReqBuilder instance
+     *
+     * @example
+     * ```typescript
+     * const tsReq = await TimeStampReq.builder()
+     *     .setData(documentBytes)
+     *     .setRandomNonce()
+     *     .setCertReq(true)
+     *     .build()
+     * ```
+     */
+    static builder(): TimeStampReqBuilder {
+        return new TimeStampReqBuilder()
+    }
+
     static create(options: {
         messageImprint: MessageImprint
         version?: number

--- a/packages/pki-lite/src/x509/Attribute.ts
+++ b/packages/pki-lite/src/x509/Attribute.ts
@@ -1,5 +1,6 @@
 import { RevocationInfoArchival } from '../adobe/RevocationInfoArchival.js'
 import { Any } from '../asn1/Any.js'
+import { BMPString } from '../asn1/BMPString.js'
 import { ObjectIdentifier } from '../asn1/ObjectIdentifier.js'
 import { OctetString } from '../asn1/OctetString.js'
 import { UTCTime } from '../asn1/UTCTime.js'
@@ -134,6 +135,14 @@ export class Attribute extends PkiBase<Attribute> {
         return new Attribute({
             type: OIDs.PKCS9.MESSAGE_DIGEST,
             values: [new OctetString({ bytes: new Uint8Array(digest) })],
+        })
+    }
+
+    static friendlyName(name: string): Attribute {
+        const bmpString = new BMPString({ value: name })
+        return new Attribute({
+            type: OIDs.PKCS9.FRIENDLY_NAME,
+            values: [bmpString.toDer()],
         })
     }
 

--- a/packages/pki-lite/src/x509/CertificateList.ts
+++ b/packages/pki-lite/src/x509/CertificateList.ts
@@ -10,6 +10,7 @@ import { TBSCertList } from './TBSCertList.js'
 import { PrivateKeyInfo } from '../keys/PrivateKeyInfo.js'
 import { Name } from './Name.js'
 import { RevokedCertificate } from './RevokedCertificate.js'
+import { CertificateListBuilder } from '../core/builders/CertificateListBuilder.js'
 import { AsymmetricEncryptionAlgorithmParams } from '../core/crypto/types.js'
 import { BitString } from '../asn1/BitString.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
@@ -125,6 +126,24 @@ export class CertificateList extends PkiBase<CertificateList> {
      * console.log(emptyCrl.tbsCertList.nextUpdate) // 30 days later
      * ```
      */
+    /**
+     * Creates a fluent builder for constructing CRLs.
+     *
+     * @returns A new CertificateListBuilder instance
+     *
+     * @example
+     * ```typescript
+     * const crl = await CertificateList.builder()
+     *     .setIssuer('CN=My CA')
+     *     .setPrivateKey(caKey)
+     *     .addRevokedCertificate({ serialNumber: 12345, revocationDate: new Date() })
+     *     .build()
+     * ```
+     */
+    static builder(): CertificateListBuilder {
+        return new CertificateListBuilder()
+    }
+
     static async createEmpty(options: {
         issuer: Name
         privateKey: PrivateKeyInfo

--- a/packages/pki-lite/src/x509/CertificateRequest.ts
+++ b/packages/pki-lite/src/x509/CertificateRequest.ts
@@ -9,6 +9,7 @@ import { AlgorithmIdentifier } from '../algorithms/AlgorithmIdentifier.js'
 import { CertificateRequestInfo } from './CertificateRequestInfo.js'
 import { BitString } from '../asn1/BitString.js'
 import { Asn1ParseError } from '../core/errors/Asn1ParseError.js'
+import { CertificateRequestBuilder } from '../core/builders/CertificateRequestBuilder.js'
 
 /**
  * Represents a PKCS#10 certificate request.
@@ -114,6 +115,25 @@ export class CertificateRequest extends PkiBase<CertificateRequest> {
 
     static fromPem(pem: string): CertificateRequest {
         return CertificateRequest.fromDer(pemToDer(pem, 'CERTIFICATE REQUEST'))
+    }
+
+    /**
+     * Creates a new certificate request builder.
+     *
+     * @returns A new CertificateRequestBuilder instance
+     * @example
+     * ```typescript
+     * const csr = await CertificateRequest.builder()
+     *     .setSubject('CN=example.com')
+     *     .setPublicKey(publicKey)
+     *     .setPrivateKey(privateKey)
+     *     .addKeyUsage({ digitalSignature: true })
+     *     .addSubjectAltName('example.com', '*.example.com')
+     *     .build()
+     * ```
+     */
+    static builder(): CertificateRequestBuilder {
+        return new CertificateRequestBuilder()
     }
 
     get pemHeader(): string {

--- a/packages/pki-lite/test-fixtures/openSsl.ts
+++ b/packages/pki-lite/test-fixtures/openSsl.ts
@@ -247,3 +247,39 @@ export async function opensslVerifyCertificate(options: {
         }
     }
 }
+
+/**
+ * Parses a PKCS#12 (PFX) file with OpenSSL using the given password and
+ * returns the extracted PEM contents (concatenated certificates and key).
+ */
+export async function opensslPkcs12Parse(options: {
+    pfx: Uint8Array
+    password: string
+}): Promise<{
+    success: boolean
+    output?: string
+    error?: string
+}> {
+    const tmpFolder = getTempFolder()
+    const pfxPath = `${tmpFolder}/in.p12`
+    fs.writeFileSync(pfxPath, options.pfx)
+
+    const args = [
+        'pkcs12',
+        '-in',
+        pfxPath,
+        '-password',
+        `pass:${options.password}`,
+        '-nodes',
+    ]
+
+    try {
+        const output = await runOpenSSL(args, tmpFolder)
+        return { success: true, output: output.toString() }
+    } catch (error) {
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+        }
+    }
+}

--- a/packages/pki-lite/test/node/openssl-compat.test.ts
+++ b/packages/pki-lite/test/node/openssl-compat.test.ts
@@ -5,6 +5,7 @@ import { rsaSigningKeys } from '../../test-fixtures/signing-keys/rsa-2048/index.
 import {
     opensslCmsDecrypt,
     opensslCmsToText,
+    opensslPkcs12Parse,
     opensslValidate,
     opensslVerifyCertificate,
 } from '../../test-fixtures/openSsl.js'
@@ -19,6 +20,7 @@ import { ContentInfo } from '../../src/pkcs7/ContentInfo.js'
 import { OIDs } from '../../src/core/OIDs.js'
 import { UTCTime } from '../../src/asn1/UTCTime.js'
 import { ecP256SigningKeys } from '../../test-fixtures/signing-keys/ec-p256/index.js'
+import { PFX } from '../../src/pkcs12/PFX.js'
 
 describe('OpenSSL compatibility', { timeout: 60000 }, () => {
     describe('EnvelopedData', () => {
@@ -552,6 +554,122 @@ describe('OpenSSL compatibility', { timeout: 60000 }, () => {
             })
 
             expect(result.success, result.error).toBe(true)
+        })
+    })
+
+    describe('PFX (PKCS#12)', () => {
+        test('PFX built with PFXBuilder is parseable by OpenSSL', async () => {
+            const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+            const privateKey = PrivateKeyInfo.fromPem(
+                rsaSigningKeys.privateKeyPem,
+            )
+            const password = 'test123'
+
+            const pfx = await PFX.builder()
+                .addCertificate(cert)
+                .addPrivateKey(privateKey)
+                .setPassword(password)
+                .build()
+
+            const result = await opensslPkcs12Parse({
+                pfx: pfx.toDer(),
+                password,
+            })
+
+            expect(result.success, result.error).toBe(true)
+            expect(result.output).toContain('BEGIN CERTIFICATE')
+            expect(result.output).toContain('BEGIN PRIVATE KEY')
+        })
+
+        test('PFX with full certificate chain is parseable by OpenSSL', async () => {
+            const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+            const caCert = Certificate.fromPem(rsaSigningKeys.caCertPem)
+            const privateKey = PrivateKeyInfo.fromPem(
+                rsaSigningKeys.privateKeyPem,
+            )
+            const password = 'chain-pass'
+
+            const pfx = await PFX.builder()
+                .addCertificate(cert, caCert)
+                .addPrivateKey(privateKey)
+                .setPassword(password)
+                .setFriendlyName('My Identity')
+                .build()
+
+            const result = await opensslPkcs12Parse({
+                pfx: pfx.toDer(),
+                password,
+            })
+
+            expect(result.success, result.error).toBe(true)
+            // Two certificates should be present in the output
+            const certCount = (result.output?.match(/BEGIN CERTIFICATE/g) ?? [])
+                .length
+            expect(certCount).toBe(2)
+            expect(result.output).toContain('BEGIN PRIVATE KEY')
+        })
+
+        test('PFX created via PFX.create is parseable by OpenSSL', async () => {
+            const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+            const privateKey = PrivateKeyInfo.fromPem(
+                rsaSigningKeys.privateKeyPem,
+            )
+            const password = 'create-pass'
+
+            const pfx = await PFX.create({
+                certificates: [cert],
+                privateKeys: [privateKey],
+                password,
+            })
+
+            const result = await opensslPkcs12Parse({
+                pfx: pfx.toDer(),
+                password,
+            })
+
+            expect(result.success, result.error).toBe(true)
+        })
+
+        test('PFX with custom iterations is parseable by OpenSSL', async () => {
+            const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+            const privateKey = PrivateKeyInfo.fromPem(
+                rsaSigningKeys.privateKeyPem,
+            )
+            const password = 'iters-pass'
+
+            const pfx = await PFX.builder()
+                .addCertificate(cert)
+                .addPrivateKey(privateKey)
+                .setPassword(password)
+                .setIterations(4096)
+                .build()
+
+            const result = await opensslPkcs12Parse({
+                pfx: pfx.toDer(),
+                password,
+            })
+
+            expect(result.success, result.error).toBe(true)
+        })
+
+        test('OpenSSL rejects PFX with wrong password (MAC verification)', async () => {
+            const cert = Certificate.fromPem(rsaSigningKeys.certPem)
+            const privateKey = PrivateKeyInfo.fromPem(
+                rsaSigningKeys.privateKeyPem,
+            )
+
+            const pfx = await PFX.builder()
+                .addCertificate(cert)
+                .addPrivateKey(privateKey)
+                .setPassword('correct-password')
+                .build()
+
+            const result = await opensslPkcs12Parse({
+                pfx: pfx.toDer(),
+                password: 'wrong-password',
+            })
+
+            expect(result.success).toBe(false)
         })
     })
 })


### PR DESCRIPTION
- implement certificate request builder for CSR creation
- add timestamp request builder for RFC 3161 requests
- create OCSP request builder for fluent construction
- add PFX builder for PKCS#12 container creation with encryption and MAC
- implement encrypted data builder for PKCS#7 encrypted data structures
- add certificate list builder for CRL construction
- enhance certificate builder with extension helper methods
- add static create methods to encrypted private key info and encrypted data
- implement HMAC support in crypto provider
- add PKCS#12 PBE algorithm support to crypto provider
- implement pkcs12Derive utility for legacy KDF (RFC 7292)
- add MacData.create for HMAC generation in PKCS#12
- add comprehensive tests for builders and OpenSSL compatibility
