### PR TITLE
fix(Validity): use GeneralizedTime for post-2049 dates

### DIFF
--- a/packages/pki-lite/src/x509/Validity.test.ts
+++ b/packages/pki-lite/src/x509/Validity.test.ts
@@ -154,6 +154,20 @@ describe('Validity', () => {
         `)
     })
 
+    test('should use GeneralizedTime to represent dates > 2049', () => {
+        const notBefore = new Date('2024-01-01T00:00:00.000Z')
+        const notAfter = new Date('2050-01-01T00:00:00.000Z')
+        const validity = new Validity({
+            notBefore: notBefore,
+            notAfter: notAfter,
+        })
+        expect(validity.toString()).toMatchInlineSnapshot(`
+          "[Validity] SEQUENCE :
+            UTCTime : 2024-01-01T00:00:00.000Z
+            GeneralizedTime : 2050-01-01T00:00:00.000Z"
+        `)
+    })
+
     test('toPem snapshot', () => {
         const notBefore = new Date('2024-01-01T00:00:00.000Z')
         const notAfter = new Date('2025-01-01T00:00:00.000Z')

--- a/packages/pki-lite/src/x509/Validity.ts
+++ b/packages/pki-lite/src/x509/Validity.ts
@@ -29,15 +29,23 @@ export class Validity extends PkiBase<Validity> {
      * Converts the validity period to an ASN.1 structure.
      */
     toAsn1(): Asn1BaseBlock {
+        // The X.509 spec says: "In no case shall UTCTime be used for
+        // representing dates beyond 2049". This is because UTCTime only uses
+        // two digits to encode the year, making it impossible to know whether
+        // for instance 50 means 1950 or 2050 (or indeed 3050).
+        // Hence, encode post-2049 Dates as GeneralizedTime.
+        const utcTimeCutoff = new Date('2050-01-01T00:00:00.000Z')
+        const notBefore =
+            this.notBefore < utcTimeCutoff
+                ? new asn1js.UTCTime({ valueDate: this.notBefore })
+                : new asn1js.GeneralizedTime({ valueDate: this.notBefore })
+        const notAfter =
+            this.notAfter < utcTimeCutoff
+                ? new asn1js.UTCTime({ valueDate: this.notAfter })
+                : new asn1js.GeneralizedTime({ valueDate: this.notAfter })
+
         return new asn1js.Sequence({
-            value: [
-                new asn1js.UTCTime({
-                    valueDate: this.notBefore,
-                }),
-                new asn1js.UTCTime({
-                    valueDate: this.notAfter,
-                }),
-            ],
+            value: [notBefore, notAfter],
         })
     }
 


### PR DESCRIPTION
Currently, pki-lite unconditionally uses `UTCTime` to encode the `notBefore` and `notAfter` fields of a `Validity` object.

As the X.509 spec ( https://www.itu.int/rec/T-REC-X.509 ) says:

> In no case shall `UTCTime` be used for representing dates beyond 2049.

This is because `UTCTime` only uses two digits to encode the year, making it impossible to know whether 50 means 1950 or 2050 (or 3050, and so on).

To fix, use `GeneralizedTime` if the `Date` in question is >= `2050-01-01T00:00:00Z`.