### PR TITLE
fix: upgrade playwright to 1.60.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@types/node": "^24.5.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.0",
-        "playwright": "^1.55.0",
+        "playwright": "^1.60.0",
         "prettier": "^3.6.2",
         "typedoc": "^0.28.13",
         "typedoc-plugin-markdown": "^4.9.0",

--- a/packages/pki-lite-crypto-extended/examples/usage.ts
+++ b/packages/pki-lite-crypto-extended/examples/usage.ts
@@ -98,8 +98,4 @@ async function demonstrateUsage() {
     )
 }
 
-// Execute the demonstration
-demonstrateUsage().catch(console.error)
-
-// Run the demonstration
-demonstrateUsage().catch(console.error)
+await demonstrateUsage()

--- a/packages/pki-lite-crypto-extended/package.json
+++ b/packages/pki-lite-crypto-extended/package.json
@@ -54,7 +54,7 @@
         "@types/node": "^24.5.1",
         "@types/node-forge": "^1.3.14",
         "@vitest/browser-playwright": "^3.2.4",
-        "playwright": "^1.55.0",
+        "playwright": "^1.60.0",
         "typescript": "6.0.3",
         "vitest": "^4.0.3"
     }

--- a/packages/pki-lite-crypto-extended/test/acceptance/__snapshots__/examples.spec.ts.snap
+++ b/packages/pki-lite-crypto-extended/test/acceptance/__snapshots__/examples.spec.ts.snap
@@ -29,5 +29,7 @@ Decrypted length: 16
 Data match: true
 
 === Standard Algorithms (Fallback) ===
+SHA-256: dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f
+SHA-256: dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f
 "
 `;

--- a/packages/pki-lite-crypto-extended/test/acceptance/__snapshots__/examples.spec.ts.snap
+++ b/packages/pki-lite-crypto-extended/test/acceptance/__snapshots__/examples.spec.ts.snap
@@ -2,18 +2,9 @@
 
 exports[`Examples > usage 1`] = `
 "=== MD5 Hashing ===
-=== MD5 Hashing ===
 MD5: 65a8e27d8879283831b664bd8b7f0ad4
 
 === AES ECB Encryption ===
-MD5: 65a8e27d8879283831b664bd8b7f0ad4
-
-=== AES ECB Encryption ===
-Original: Secret message!!
-Decrypted: Secret message!!
-Match: true
-
-=== AES CBC (No Padding) ===
 Original: Secret message!!
 Decrypted: Secret message!!
 Match: true
@@ -24,12 +15,6 @@ Decrypted length: 16
 Data match: true
 
 === Standard Algorithms (Fallback) ===
-Original length: 16
-Decrypted length: 16
-Data match: true
-
-=== Standard Algorithms (Fallback) ===
-SHA-256: dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f
 SHA-256: dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f
 "
 `;

--- a/packages/pki-lite/package.json
+++ b/packages/pki-lite/package.json
@@ -59,7 +59,7 @@
     "devDependencies": {
         "@types/node": "^24.3.3",
         "@vitest/browser-playwright": "^3.2.4",
-        "playwright": "^1.55.0",
+        "playwright": "^1.60.0",
         "typescript": "6.0.3",
         "vitest": "^4.0.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   vitest: ^4.0.13
   '@vitest/browser-playwright': ^4.0.13
   typescript: ^6.0.2
-  playwright: ^1.55.0
+  playwright: ^1.60.0
 
 importers:
 
@@ -529,7 +529,7 @@ packages:
   '@vitest/browser-playwright@4.0.13':
     resolution: {integrity: sha512-oaRY+/pvwS4/sN2rE2aZh9jdli8EkXm5AidmXEbWRu2wW0omG9PmgChWCX2jsD9qRLQxXTSLl5oKezANNF6LnQ==}
     peerDependencies:
-      playwright: ^1.55.0
+      playwright: ^1.60.0
       vitest: ^4.0.13
 
   '@vitest/browser@4.0.13':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,97 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 10.33.2
-        version: 10.33.2
-      pnpm:
-        specifier: 10.33.2
-        version: 10.33.2
-
-packages:
-
-  '@pnpm/exe@10.33.2':
-    resolution: {integrity: sha512-jMTAKcTBptqD6xsm0oyF2q4S5zlhvVm70uwfmkfNED3S5V3vr6JRykV/xwt1qKd5ChLMONquKemNuVSrmUvx1w==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@10.33.2':
-    resolution: {integrity: sha512-t7riiqXKzj3r2hy3SVkwiHnJB/9ussTLnSqA/6h9x5zuLlj9LZB3wla96hZDem2+wsLQ4xsMMVyZ1Rn1BGsH7w==}
-    cpu: [arm64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/linux-x64@10.33.2':
-    resolution: {integrity: sha512-tWwfiXIvZwnnsNR0GJj2DWSWW5UsJCq+zd62LrGiB9IBT5e/oPDPo1uV88UGpfJGNNHexGQuczi4oYocnTkZNA==}
-    cpu: [x64]
-    os: [linux]
-    hasBin: true
-
-  '@pnpm/macos-arm64@10.33.2':
-    resolution: {integrity: sha512-4Gp5kO+sZBtmUScajoodNu8id58b6K3iNeChyKYrmiTc4EmAAcAFcwbXty0gTs5/GJaWtgT9NOuhDzx1e33eiw==}
-    cpu: [arm64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/macos-x64@10.33.2':
-    resolution: {integrity: sha512-en+5m6ygIik49Nbj1V+CUf7tzLWadnxpjVJiM/POd+P0JovR7sodlu93oHEOze/T2vunHhjTpnGk+qsafM5kuw==}
-    cpu: [x64]
-    os: [darwin]
-    hasBin: true
-
-  '@pnpm/win-arm64@10.33.2':
-    resolution: {integrity: sha512-ZJQaXG20k4efIFcITv53pyGk+0E13vBHbhdqcIZeF4Euw7iUNwb4F2ID4hnTW82NrvaI1woeS5cIPJSCrFpsxQ==}
-    cpu: [arm64]
-    os: [win32]
-    hasBin: true
-
-  '@pnpm/win-x64@10.33.2':
-    resolution: {integrity: sha512-A2zrjz2Ii/wdHBh83fMT6MtJ1WFSbQEDD9RCBVnC60fRcWda4+M2UoIDvwSiq+eTRRGj29ljFIE2FWzEDEQdbA==}
-    cpu: [x64]
-    os: [win32]
-    hasBin: true
-
-  pnpm@10.33.2:
-    resolution: {integrity: sha512-qQ+vb+6rca1sblf5Tg/hoS9dzCLNdU20CulZPraj4LaxLjVAIYuzeuCDQEsfLObbKkEh6XmCm0r/lLmfSdoc+A==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@10.33.2':
-    optionalDependencies:
-      '@pnpm/linux-arm64': 10.33.2
-      '@pnpm/linux-x64': 10.33.2
-      '@pnpm/macos-arm64': 10.33.2
-      '@pnpm/macos-x64': 10.33.2
-      '@pnpm/win-arm64': 10.33.2
-      '@pnpm/win-x64': 10.33.2
-
-  '@pnpm/linux-arm64@10.33.2':
-    optional: true
-
-  '@pnpm/linux-x64@10.33.2':
-    optional: true
-
-  '@pnpm/macos-arm64@10.33.2':
-    optional: true
-
-  '@pnpm/macos-x64@10.33.2':
-    optional: true
-
-  '@pnpm/win-arm64@10.33.2':
-    optional: true
-
-  '@pnpm/win-x64@10.33.2':
-    optional: true
-
-  pnpm@10.33.2: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -131,8 +37,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0
       playwright:
-        specifier: ^1.55.0
-        version: 1.55.0
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -160,10 +66,10 @@ importers:
         version: 24.5.2
       '@vitest/browser-playwright':
         specifier: ^4.0.13
-        version: 4.0.13(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
+        version: 4.0.13(playwright@1.60.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
       playwright:
-        specifier: ^1.55.0
-        version: 1.55.0
+        specifier: ^1.60.0
+        version: 1.60.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -194,10 +100,10 @@ importers:
         version: 1.3.14
       '@vitest/browser-playwright':
         specifier: ^4.0.13
-        version: 4.0.13(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
+        version: 4.0.13(playwright@1.60.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
       playwright:
-        specifier: ^1.55.0
-        version: 1.55.0
+        specifier: ^1.60.0
+        version: 1.60.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -1070,13 +976,13 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
-  playwright-core@1.55.0:
-    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.55.0:
-    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1717,11 +1623,11 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vitest/browser-playwright@4.0.13(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)':
+  '@vitest/browser-playwright@4.0.13(playwright@1.60.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)':
     dependencies:
       '@vitest/browser': 4.0.13(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
       '@vitest/mocker': 4.0.13(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))
-      playwright: 1.55.0
+      playwright: 1.60.0
       tinyrainbow: 3.0.3
       vitest: 4.0.13(@types/node@24.5.2)(@vitest/browser-playwright@4.0.13)(jiti@2.6.0)(yaml@2.8.4)
     transitivePeerDependencies:
@@ -2156,11 +2062,11 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  playwright-core@1.55.0: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.55.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.55.0
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -2364,7 +2270,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.5.2
-      '@vitest/browser-playwright': 4.0.13(playwright@1.55.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
+      '@vitest/browser-playwright': 4.0.13(playwright@1.60.0)(vite@7.1.6(@types/node@24.5.2)(jiti@2.6.0)(yaml@2.8.4))(vitest@4.0.13)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

- Upgrades playwright to 1.60.0 to fix browser installation hang on GitHub Actions (microsoft/playwright#40998)
- Regenerates lockfile to reconcile `overrides` config mismatch
- Updates acceptance snapshot and fixes `usage.ts` example to use `await` instead of two fire-and-forget calls (caused non-deterministic output between node and browser environments)

## Test plan

- [ ] CI passes on this PR