### PR TITLE
fix(x509): fix encoding and decoding unused bits

### DIFF
--- a/packages/pki-lite/src/x509/ReasonFlags.test.ts
+++ b/packages/pki-lite/src/x509/ReasonFlags.test.ts
@@ -61,6 +61,36 @@ describe('ReasonFlags', () => {
         expect(decoded.aACompromise).toEqual(false)
     })
 
+    it('should encode unusedBits correctly', () => {
+        const flags = new ReasonFlags({
+            certificateHold: true,
+            aACompromise: true,
+        })
+
+        const asn1 = flags.toAsn1()
+
+        expect(asn1).toBeInstanceOf(asn1js.BitString)
+        const bitString = asn1 as asn1js.BitString
+        expect(bitString.valueBlock.unusedBits).toEqual(7)
+        expect(Array.from(bitString.valueBlock.valueHexView)).toEqual([
+            0b0000_0010, 0b1000_0000,
+        ])
+    })
+
+    it('should decode unusedBits correctly', () => {
+        const asn1 = new asn1js.BitString({
+            valueHex: new Uint8Array([0b0000_0010, 0b1000_0000]).buffer,
+            unusedBits: 7,
+        })
+
+        const decoded = ReasonFlags.fromAsn1(asn1)
+
+        expect(decoded.cessationOfOperation).toEqual(false)
+        expect(decoded.certificateHold).toEqual(true)
+        expect(decoded.privilegeWithdrawn).toEqual(false)
+        expect(decoded.aACompromise).toEqual(true)
+    })
+
     it('should throw if ASN.1 is not a BitString', () => {
         expect(() => ReasonFlags.fromAsn1(new asn1js.Null())).toThrow(
             'ReasonFlags: Expected BitString for ReasonFlags',

--- a/packages/pki-lite/src/x509/ReasonFlags.ts
+++ b/packages/pki-lite/src/x509/ReasonFlags.ts
@@ -67,18 +67,17 @@ export class ReasonFlags extends PkiBase<ReasonFlags> {
             this.aACompromise,
         ]
         // Always encode all 9 bits (ReasonFlags flags)
-        const unusedBits = (8 - ((bits.length - 1) % 8)) % 8
         const byteLength = Math.ceil(bits.length / 8)
-        const bytes = new Uint8Array(byteLength + 1) // +1 for unused bits byte
-        bytes[0] = unusedBits
+        const unusedBits = byteLength * 8 - bits.length
+        const bytes = new Uint8Array(byteLength)
         for (let i = 0; i < bits.length; i++) {
             if (bits[i] === true) {
-                const byteIndex = Math.floor(i / 8) + 1 // +1 for unused bits byte
+                const byteIndex = Math.floor(i / 8)
                 const bitIndex = 7 - (i % 8)
                 bytes[byteIndex] |= 1 << bitIndex
             }
         }
-        return new asn1js.BitString({ valueHex: bytes.buffer })
+        return new asn1js.BitString({ valueHex: bytes.buffer, unusedBits })
     }
 
     static fromAsn1(asn1: Asn1BaseBlock): ReasonFlags {
@@ -93,12 +92,12 @@ export class ReasonFlags extends PkiBase<ReasonFlags> {
             throw new Asn1ParseError('ReasonFlags: BitString has no content')
         }
 
-        const unusedBits = bytes[0]
-        const totalBits = (bytes.length - 1) * 8 - unusedBits
+        const unusedBits = asn1.valueBlock.unusedBits
+        const totalBits = bytes.length * 8 - unusedBits
 
         const bits: (0 | 1)[] = []
         for (let i = 0; i < totalBits; i++) {
-            const byteIndex = Math.floor(i / 8) + 1 // +1 for unused bits byte
+            const byteIndex = Math.floor(i / 8)
             const bitIndex = 7 - (i % 8)
             const bit = (bytes[byteIndex] >> bitIndex) & 1
             bits.push(bit as 0 | 1)

--- a/packages/pki-lite/src/x509/extensions/KeyUsage.test.ts
+++ b/packages/pki-lite/src/x509/extensions/KeyUsage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { KeyUsage } from './KeyUsage.js'
+import { asn1js } from '../../core/PkiBase.js'
 
 describe('KeyUsage', () => {
     it('should create a KeyUsage with correct properties', () => {
@@ -78,6 +79,37 @@ describe('KeyUsage', () => {
         expect(decoded.keyAgreement).toEqual(false)
         expect(decoded.keyCertSign).toEqual(false)
         expect(decoded.cRLSign).toEqual(false)
+        expect(decoded.encipherOnly).toEqual(false)
+        expect(decoded.decipherOnly).toEqual(false)
+    })
+
+    it('should encode unusedBits correctly', () => {
+        const usage = new KeyUsage({
+            cRLSign: true,
+            keyCertSign: true,
+        })
+
+        const asn1 = usage.toAsn1()
+
+        expect(asn1).toBeInstanceOf(asn1js.BitString)
+        const bitString = asn1 as asn1js.BitString
+        expect(bitString.valueBlock.unusedBits).toEqual(7)
+        expect(Array.from(bitString.valueBlock.valueHexView)).toEqual([
+            0b0000_0110, 0b0000_0000,
+        ])
+    })
+
+    it('should decode unusedBits correctly', () => {
+        const asn1 = new asn1js.BitString({
+            valueHex: new Uint8Array([0b0000_0110, 0b0000_0000]).buffer,
+            unusedBits: 7,
+        })
+
+        const decoded = KeyUsage.fromAsn1(asn1)
+
+        expect(decoded.keyAgreement).toEqual(false)
+        expect(decoded.cRLSign).toEqual(true)
+        expect(decoded.keyCertSign).toEqual(true)
         expect(decoded.encipherOnly).toEqual(false)
         expect(decoded.decipherOnly).toEqual(false)
     })

--- a/packages/pki-lite/src/x509/extensions/KeyUsage.ts
+++ b/packages/pki-lite/src/x509/extensions/KeyUsage.ts
@@ -68,18 +68,17 @@ export class KeyUsage extends PkiBase<KeyUsage> {
             this.decipherOnly,
         ]
         // Always encode all 9 bits (KeyUsage flags)
-        const unusedBits = (8 - ((bits.length - 1) % 8)) % 8
         const byteLength = Math.ceil(bits.length / 8)
-        const bytes = new Uint8Array(byteLength + 1) // +1 for unused bits byte
-        bytes[0] = unusedBits
+        const unusedBits = byteLength * 8 - bits.length
+        const bytes = new Uint8Array(byteLength)
         for (let i = 0; i < bits.length; i++) {
             if (bits[i] === true) {
-                const byteIndex = Math.floor(i / 8) + 1 // +1 for unused bits byte
+                const byteIndex = Math.floor(i / 8)
                 const bitIndex = 7 - (i % 8)
                 bytes[byteIndex] |= 1 << bitIndex
             }
         }
-        return new asn1js.BitString({ valueHex: bytes.buffer })
+        return new asn1js.BitString({ valueHex: bytes.buffer, unusedBits })
     }
 
     static fromAsn1(asn1: Asn1BaseBlock): KeyUsage {
@@ -92,12 +91,12 @@ export class KeyUsage extends PkiBase<KeyUsage> {
             throw new Asn1ParseError('BitString has no content')
         }
 
-        const unusedBits = bytes[0]
-        const totalBits = (bytes.length - 1) * 8 - unusedBits
+        const unusedBits = asn1.valueBlock.unusedBits
+        const totalBits = bytes.length * 8 - unusedBits
 
         const bits: (0 | 1)[] = []
         for (let i = 0; i < totalBits; i++) {
-            const byteIndex = Math.floor(i / 8) + 1 // +1 for unused bits byte
+            const byteIndex = Math.floor(i / 8)
             const bitIndex = 7 - (i % 8)
             const bit = (bytes[byteIndex] >> bitIndex) & 1
             bits.push(bit as 0 | 1)


### PR DESCRIPTION
Unused bits should be passed to BitString separately to encode them properly.

Fixes #118.