### PR TITLE
Add `as const` to `OIDs` object

### DIFF
--- a/packages/pki-lite/src/core/OIDs.ts
+++ b/packages/pki-lite/src/core/OIDs.ts
@@ -357,7 +357,7 @@ export const OIDs = {
         REVOCATION_INFO_ARCHIVAL: '1.2.840.113583.1.1.8',
     },
     getOidFriendlyName,
-}
+} as const
 
 /**
  * Mapping of PKCS#7 content type names to their OIDs.

--- a/packages/pki-lite/src/core/OIDs.ts
+++ b/packages/pki-lite/src/core/OIDs.ts
@@ -484,7 +484,6 @@ export const OIDToFriendlyName: Record<string, string> = {
     [OIDs.DN.EMAIL]: 'Email Address',
 
     // PKCS#9 Attributes
-    [OIDs.PKCS9.EMAIL_ADDRESS]: 'Email Address',
     [OIDs.PKCS9.CONTENT_TYPE]: 'Content Type',
     [OIDs.PKCS9.MESSAGE_DIGEST]: 'Message Digest',
     [OIDs.PKCS9.SIGNING_TIME]: 'Signing Time',


### PR DESCRIPTION
This makes TypeScript report the the actual OID value instead of just `string` for the members, e.g. the type of `OIDs.RSA.ENCRYPTION` becomes `"1.2.840.113549.1.1.1"` instead of the opaque `string`.

In passing, remove a duplicate entry from `OIDToFriendlyName`, which the `as const` change turns into a type error.

## Visual Changes

This change is mostly cosmetic; it just makes using `OIDs` a bit nicer.

### Before

<img width="564" height="198" alt="image" src="https://github.com/user-attachments/assets/bddac30e-18f1-4a1e-88cc-58d6251f8882" />

### After

<img width="663" height="200" alt="image" src="https://github.com/user-attachments/assets/a315e318-a91b-42ee-b536-b36172cefbb2" />
