### PR TITLE
chore: require dependencies to be at least 1 month old

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
     - 'packages/*'
 
+# Only install package versions published at least 30 days ago
+minimumReleaseAge: 43200
+
 overrides:
     vitest: $vitest
     '@vitest/browser-playwright': $vitest

--- a/renovate.json
+++ b/renovate.json
@@ -13,13 +13,10 @@
     "labels": ["deps"],
     "dependencyDashboard": true,
     "ignorePaths": ["**/node_modules/**"],
+    "minimumReleaseAge": "1 month",
     "timezone": "Europe/London",
     "schedule": ["after 2am every weekday", "before 5am every weekday"],
     "packageRules": [
-        {
-            "minimumReleaseAge": "3 days",
-            "matchPackageNames": ["/npm/"]
-        },
         {
             "groupName": "patch updates",
             "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
Adds a one-month minimum release age policy for dependencies.

- `pnpm-workspace.yaml`: `minimumReleaseAge: 43200` (minutes = 30 days), so pnpm will not install versions published more recently than that.
- `renovate.json`: top-level `minimumReleaseAge: "1 month"`, replacing the previous 3-day rule that only matched package names containing `npm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)